### PR TITLE
fix failure without preJDK7 flag

### DIFF
--- a/src/main/scala/org/scalameter/utils/package.scala
+++ b/src/main/scala/org/scalameter/utils/package.scala
@@ -11,7 +11,7 @@ import JavaConversions._
 package object utils {
 
   def withGCNotification[T](eventhandler: Notification => Any) = new {
-    def apply(body: =>T): T = if (!initialContext[Boolean](Key.preJDK7)) {
+    def apply(body: =>T): T = if (!initialContext.goe[Boolean](Key.preJDK7, false)) {
       val gcbeans = java.lang.management.ManagementFactory.getGarbageCollectorMXBeans
       val listeners = for (gcbean <- gcbeans) yield {
         val listener = new NotificationListener {

--- a/src/test/scala/org/scalameter/QuickbenchmarkTest.scala
+++ b/src/test/scala/org/scalameter/QuickbenchmarkTest.scala
@@ -1,0 +1,27 @@
+package org.scalameter
+
+import org.scalatest.FunSuite
+import org.scalameter.api._
+
+import util.Properties.javaVersion
+
+class QuickbenchmarkTest extends FunSuite {
+
+  object SomeBenchmark extends PerformanceTest.Quickbenchmark {
+
+    performance of "single" in {
+      using(Gen.single("single")(1)) in (_ + 0)
+    }
+  }
+
+  test("A benchmark should start without any command line params for Java 1.7") {
+    if (!(javaVersion startsWith ("1.7"))) pending
+    SomeBenchmark.main(Array())
+  }
+
+  test("A benchmark should start with '-preJDK7' command line flag for Java 1.6") {
+    if (!(javaVersion startsWith ("1.6"))) pending
+    SomeBenchmark.main(Array("-preJDK7"))
+  }
+
+}


### PR DESCRIPTION
Hi there,
I was playing with scalameter and found that master is kind of broken.
When I tried to run a Quickbenchmark it gave me  the following exception

Exception in thread "main" java.util.NoSuchElementException: key not found: pre-jdk-7
    at scala.collection.MapLike$class.default(MapLike.scala:228)
    at scala.collection.AbstractMap.default(Map.scala:58)
    at scala.collection.MapLike$class.apply(MapLike.scala:141)
    at scala.collection.AbstractMap.apply(Map.scala:58)
    at org.scalameter.Context.apply(package.scala:175)
    at org.scalameter.utils.package$$anon$2.apply(package.scala:14)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.scalameter.Executor$Warmer$Default$$anon$1.foreach(Executor.scala:62)
    at org.scalameter.execution.LocalExecutor$$anonfun$run$1$$anonfun$apply$1.apply(LocalExecutor.scala:40)
    at org.scalameter.execution.LocalExecutor$$anonfun$run$1$$anonfun$apply$1.apply(LocalExecutor.scala:37)
    at scala.collection.Iterator$class.foreach(Iterator.scala:727)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1156)
    at org.scalameter.execution.LocalExecutor$$anonfun$run$1.apply(LocalExecutor.scala:37)
    at org.scalameter.execution.LocalExecutor$$anonfun$run$1.apply(LocalExecutor.scala:35)
    at org.scalameter.utils.Tree$$anonfun$foreach$2$$anonfun$apply$1.apply(Tree.scala:13)
    at org.scalameter.utils.Tree$$anonfun$foreach$1.apply(Tree.scala:12)
    at scala.collection.immutable.List.foreach(List.scala:309)
    at org.scalameter.utils.Tree.foreach(Tree.scala:12)
    at org.scalameter.utils.Tree$$anonfun$foreach$2.apply(Tree.scala:13)
    at org.scalameter.utils.Tree$$anonfun$foreach$2.apply(Tree.scala:13)
    at scala.collection.immutable.List.foreach(List.scala:309)
    at org.scalameter.utils.Tree.foreach(Tree.scala:13)
    at org.scalameter.execution.LocalExecutor.run(LocalExecutor.scala:35)
    at org.scalameter.PerformanceTest$Initialization$class.executeTests(PerformanceTest.scala:43)
    at org.scalameter.PerformanceTest.executeTests(PerformanceTest.scala:10)
    at org.scalameter.PerformanceTest$$anonfun$1.apply$mcZ$sp(PerformanceTest.scala:15)
    at org.scalameter.PerformanceTest$$anonfun$1.apply(PerformanceTest.scala:15)
    at org.scalameter.PerformanceTest$$anonfun$1.apply(PerformanceTest.scala:15)
    at scala.util.DynamicVariable.withValue(DynamicVariable.scala:57)
    at org.scalameter.PerformanceTest.main(PerformanceTest.scala:14)
    at com.jozic.sorts.SortBenchmark.main(SortBenchmark.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:120)

So I've fixed it and have added some simple tests.
I would be glad to hear your code review comments and fix them, if needed.

Thanks,
Eugene
