### PR TITLE
make easier to create benchmarks with default regen frequency

### DIFF
--- a/src/main/scala/org/scalameter/Executor.scala
+++ b/src/main/scala/org/scalameter/Executor.scala
@@ -200,9 +200,12 @@ object Executor {
 
       abstract override def name = s"${super.name}+PeriodicReinstantiation"
 
+      def defaultFrequency = 10
+      def defaultFullGC = false
+
       protected override def valueAt[T](context: Context, iteration: Int, regen: () => T, v: T) = {
-        val freq = context.goe(frequency, 10)
-        val fullgc = context.goe(fullGC, false)
+        val freq = context.goe(frequency, defaultFrequency)
+        val fullgc = context.goe(fullGC, defaultFullGC)
 
         if ((iteration + 1) % freq == 0) {
           log.verbose("Reinstantiating benchmark value.")

--- a/src/main/scala/org/scalameter/PerformanceTest.scala
+++ b/src/main/scala/org/scalameter/PerformanceTest.scala
@@ -57,8 +57,9 @@ object PerformanceTest {
     def executor = new execution.LocalExecutor(
       Executor.Warmer.Default(),
       Aggregator.min,
-      new Executor.Measurer.Default
+      measurer
     )
+    def measurer = new Executor.Measurer.Default
     def reporter = new reporting.LoggingReporter
     def persistor = Persistor.None
   }
@@ -68,8 +69,8 @@ object PerformanceTest {
     def warmer = Executor.Warmer.Default()
     def aggregator = Aggregator.min
     def measurer = new Measurer.IgnoringGC with Measurer.PeriodicReinstantiation {
-      def frequency = 12
-      def fullGC = true
+      override val defaultFrequency = 12
+      override val defaultFullGC = true
     }
     def executor = execution.SeparateJvmsExecutor(warmer, aggregator, measurer)
     def reporter = new reporting.LoggingReporter


### PR DESCRIPTION
Hey Alex,

I was trying to configure regeneration of the data for my sorts benchmarks, and I've found it would be easier if I override default frequency for PeriodicReinstantiation trait

so my code looks like this

```
object SortBenchmark extends PerformanceTest.Quickbenchmark {
  override def measurer = new Measurer.Default with Measurer.PeriodicReinstantiation {
    override val defaultFrequency = 1
  }
  // bunch of performance tests
}
```

I would be glad to hear your feedback.

Thanks,
Eugene
