### PR TITLE
Topic/accumulate tests in hierarchies

### DIFF
--- a/src/main/scala/org/scalameter/PerformanceTest.scala
+++ b/src/main/scala/org/scalameter/PerformanceTest.scala
@@ -53,6 +53,7 @@ object PerformanceTest {
       // over this value and not testbody itself.
       val current = testbody.value
       testbody.value = () => { current(); body }
+      testbodySet = true
     }
 
   }

--- a/src/main/scala/org/scalameter/dsl.scala
+++ b/src/main/scala/org/scalameter/dsl.scala
@@ -11,7 +11,13 @@ trait DSL {
 
   import DSL._
 
-  private[scalameter] val testbody = new DynamicVariable[() => Any](() => ())
+  protected[scalameter] var testbodySet = false
+  private[scalameter] val testbody = new DynamicVariable[() => Any]{_ =>
+      if (!testbodySet)
+        ???
+      else
+        ()
+    }
 
   object performance {
     def of(modulename: String) = Scope(modulename, setupzipper.value.current.context)


### PR DESCRIPTION
Ensure that all tests are executed in code like this:

``` scala
class A extends PerformanceTest {
  //some tests
}
class B extends A {
 //other tests
}
```

EDIT: Currently, only the "other tests", defined in `B`, are executed, not the ones in `A`.

In the above code, `delayedInit` is called twice:

``` scala
class A extends DelayedInit {
  def delayedInit(body: => Unit) {
    println("delayedInit START")
    body
    println("delayedInit END")
  }
  println("A's constructor!")
}
class B extends A {
  println("B's constructor!")
}
```

REPL interaction for the above minimal test:

```
scala> new B
delayedInit START
A's constructor!
delayedInit END
delayedInit START
B's constructor!
delayedInit END
```

I verified this behavior in 2.10.2, and it seems to agree with a careful reading of the specification and documentation of `DelayedInit`, since both `A` and `B` inherit from `DelayedInit` hence their constructors are both transformed.
