### PR TITLE
Fixed syntax error

### DIFF
--- a/src/main/scala/org/scalameter/dsl.scala
+++ b/src/main/scala/org/scalameter/dsl.scala
@@ -12,12 +12,12 @@ trait DSL {
   import DSL._
 
   protected[scalameter] var testbodySet = false
-  private[scalameter] val testbody = new DynamicVariable[() => Any]{_ =>
+  private[scalameter] val testbody = new DynamicVariable[() => Any]({ () =>
       if (!testbodySet)
         ???
       else
         ()
-    }
+    })
 
   object performance {
     def of(modulename: String) = Scope(modulename, setupzipper.value.current.context)


### PR DESCRIPTION
```
[error] /localhome/jenkins/c/workspace/scalameter-wip-nightly/src/main/scala/org/scalameter/dsl.scala:15: not enough arguments for constructor DynamicVariable: (init: () => Any)scala.util.DynamicVariable[() => Any].
[error] Unspecified value parameter init.
[error]   private[scalameter] val testbody = new DynamicVariable[() => Any]{_ =>
[error]                                          ^
[error] one error found
[error] (compile:compile) Compilation failed
```

https://scala-webapps.epfl.ch/jenkins/view/All/job/scalameter-wip-nightly/1/console
