### PR TITLE
Why isn't embedDsv in HtmlReporter true by default

### DIFF
--- a/src/main/scala/org/scalameter/reporting/HtmlReporter.scala
+++ b/src/main/scala/org/scalameter/reporting/HtmlReporter.scala
@@ -15,7 +15,7 @@ import Key._
 
 
 
-case class HtmlReporter(val embedDsv: Boolean) extends Reporter {
+case class HtmlReporter(val embedDsv: Boolean = true) extends Reporter {
   import HtmlReporter._
 
   def report(result: CurveData, persistor: Persistor) {


### PR DESCRIPTION
It seems for me that it will be more convenient for user to, by default, generate web pages that can be simply opened with browser from local filesystem, without requiring to either tweak security policy or setting up local webserver. 
