### PR TITLE
build update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-  - "2.10.3"
-  - "2.11.0-RC1"
+  - "2.10.4"
+  - "2.11.0-RC3"
 jdk:
   - oraclejdk7
 script: sbt ++${TRAVIS_SCALA_VERSION} test $(if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then echo "publish"; fi)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,8 +24,8 @@ object ScalaMeterBuild extends Build {
   })
 
   val scalaMeterSettings = Defaults.defaultSettings ++ publishCreds ++ Seq(
-    scalaVersion := "2.10.3",
-    crossScalaVersions := Seq("2.10.3", "2.11.0-RC1"),
+    scalaVersion := "2.10.4",
+    crossScalaVersions := Seq("2.10.4", "2.11.0-RC3"),
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xlint"),
     resolvers ++= Seq(
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
@@ -64,25 +64,25 @@ object ScalaMeterBuild extends Build {
       </developers>
   )
 
-  def dependencies(scalaVersion: String) = {
-    scalaVersion match {
-      case "2.10.3" => Seq(
-        "org.scalatest" %% "scalatest" % "2.1.0" % "test",
-        "com.github.wookietreiber" %% "scala-chart" % "0.4.0-SNAPSHOT",
-        "org.apache.commons" % "commons-math3" % "3.2",
-        "org.scala-tools.testing" % "test-interface" % "0.5"
-      )
-      case "2.11.0-RC1" => Seq(
-        "org.scalatest" %% "scalatest" % "2.1.0" % "test",
-        "com.github.wookietreiber" %% "scala-chart" % "0.4.0-SNAPSHOT",
-        "org.apache.commons" % "commons-math3" % "3.2",
-        "org.scala-tools.testing" % "test-interface" % "0.5",
-        "org.scala-lang" % "scala-reflect" % "2.11.0-RC1",
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.0",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.0"
-      )
-      case _ => Seq()
-    }
+  def dependencies(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2,11)) => List (
+      "org.scalatest" %% "scalatest" % "2.1.2" % "test",
+      "com.github.wookietreiber" %% "scala-chart" % "0.4.0-SNAPSHOT",
+      "org.apache.commons" % "commons-math3" % "3.2",
+      "org.scala-tools.testing" % "test-interface" % "0.5",
+      "org.scala-lang" % "scala-reflect" % "2.11.0-RC3",
+      "org.scala-lang.modules" %% "scala-xml" % "1.0.1",
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
+    )
+
+    case Some((2,10)) => List (
+      "org.scalatest" %% "scalatest" % "2.1.0" % "test",
+      "com.github.wookietreiber" %% "scala-chart" % "0.4.0-SNAPSHOT",
+      "org.apache.commons" % "commons-math3" % "3.2",
+      "org.scala-tools.testing" % "test-interface" % "0.5"
+    )
+
+    case _ => Nil
   }
 
   /* projects */


### PR DESCRIPTION
- uses scala versions `2.10.4` and `2.11.0-RC3` now
- updates some dependencies accordingly
- also uses pattern matching on `CrossVersion.partialVersion(scalaVersion)` for the dependencies
- this also fixes the issues regarding `2.11.0-RC1` and the scala-chart snapshot update (#71)
