### PR TITLE
Allow being loaded by bootclassloader.

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/utils/ClassPath.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/utils/ClassPath.scala
@@ -8,6 +8,7 @@ object ClassPath {
   def extract(classLoader: ClassLoader, default: => String): String =
     classLoader match {
       case urlclassloader: java.net.URLClassLoader => extractFromUrlCL(urlclassloader)
+      case null => sys.props("sun.boot.class.path")
       case _ =>
         val parent = classLoader.getParent
         if (parent != null)


### PR DESCRIPTION
From documentation: 

> Some implementations may use null to represent the bootstrap class loader. This method will return null in such implementations if this class was loaded by the bootstrap class loader.
