### PR TITLE
PerformanceTest should inherit default configuration.

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/package.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/package.scala
@@ -51,6 +51,15 @@ package object scalameter extends MeasureBuilder[Unit, Double](
   def extractClasspath(classLoader: ClassLoader, default: => String): String =
     ClassPath.extract(classLoader, default)
 
+  def withTestContext[U](ctx: Context, log: Log, handler: Events)(body: =>U) = {
+    var res: U = null.asInstanceOf[U]
+    for {
+      _ <- dyn.log.using(log)
+      _ <- dyn.events.using(handler)
+      _ <- dyn.currentContext.using(ctx)
+    } res = body
+    res
+  }
 }
 
 

--- a/src/main/scala/org/scalameter/PerformanceTest.scala
+++ b/src/main/scala/org/scalameter/PerformanceTest.scala
@@ -10,8 +10,8 @@ import java.util.Date
 abstract class PerformanceTest extends PerformanceTest.Initialization with Serializable {
 
   def main(args: Array[String]) {
-    val ctx = Main.Configuration.fromCommandLineArgs(args).context
-    val ok = dyn.currentContext.withValue(ctx) {
+    val ctx = dyn.currentContext.value ++ Main.Configuration.fromCommandLineArgs(args).context
+    val ok = withTestContext(ctx, Log.Console, Events.None) {
       executeTests()
     }
 


### PR DESCRIPTION
Factored out common configuration logic for dyn fields into
withTestContext helper method.

see #85 for discussion.
