### PR TITLE
Add possiblity to report time in nano seconds to Default measurer

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/Measurer.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/Measurer.scala
@@ -36,8 +36,20 @@ object Measurer {
 
   }
 
+  object Default {
+    def apply() = new Default
+
+    def withNanos() = new Default(conversionFun = _.toDouble) {
+       override def units = "ns"
+    }
+  }
+
   /** A default measurer executes the test as many times as specified and returns the sequence of measured times. */
-  class Default extends Timer with IterationBasedValue {
+  class Default private(conversionFun: Long => Double) extends Timer with IterationBasedValue {
+    def this() {
+      this(conversionFun = _ / 1000000.0)
+    }
+
     def name = "Measurer.Default"
 
     def measure[T, U](context: Context, measurements: Int, setup: T => Any, tear: T => Any, regen: () => T, snippet: T => Any): Seq[Double] = {
@@ -52,7 +64,7 @@ object Measurer {
         val start = System.nanoTime
         snippet(value)
         val end = System.nanoTime
-        val time = (end - start) / 1000000.0
+        val time = conversionFun(end - start)
 
         tear(value)
 

--- a/src/main/scala/org/scalameter/japi/japi.scala
+++ b/src/main/scala/org/scalameter/japi/japi.scala
@@ -107,6 +107,11 @@ class DefaultMeasurer extends Measurer {
 }
 
 
+class DefaultWithNanosMeasurer extends Measurer {
+  def get = org.scalameter.Executor.Measurer.Default.withNanos()
+}
+
+
 class TimeWithIgnoringGCMeasurer extends Measurer {
   def get = new org.scalameter.Executor.Measurer.IgnoringGC
 }


### PR DESCRIPTION
Added possibility to report time in nanos to Default Measurer - reporting in 'ms' is default behaviour.
It should fix #94