### PR TITLE
Trigger build of scalameter-examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,7 @@ env:
 branches:
   only:
     - master
+after_success:
+  - chmod 755 ./tools/build_examples.sh
+  - ./tools/build_examples.sh
 

--- a/tools/build-examples.sh
+++ b/tools/build-examples.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Taken and adapted from: https://github.com/ajdm/travis-build-children
+
+# Get last child project build number
+BUILD_NUM=$(curl -s 'https://api.travis-ci.org/repos/scalameter/scalameter-examples/builds' | grep -o '^\[{"id":[0-9]*,' | grep -o '[0-9]' | tr -d '\n')
+# Restart last child project build
+curl -X POST https://api.travis-ci.org/builds/$BUILD_NUM/restart --header "Authorization: token "$AUTH_TOKEN


### PR DESCRIPTION
Note that it requires travis auth token - preferably encrypted with `travis encrypt AUTH_TOKEN=<travis_token>` ;-)