### PR TITLE
Add json based persistors to org.scalameter.api

### DIFF
--- a/src/main/scala/org/scalameter/api.scala
+++ b/src/main/scala/org/scalameter/api.scala
@@ -77,4 +77,9 @@ object api extends Keys {
   type SerializationPersistor = persistence.SerializationPersistor
   val SerializationPersistor = persistence.SerializationPersistor
 
+  type JSONSerializationPersistor = persistence.JSONSerializationPersistor
+  val JSONSerializationPersistor = persistence.JSONSerializationPersistor
+
+  type GZIPJSONSerializationPersistor = persistence.GZIPJSONSerializationPersistor
+  val GZIPJSONSerializationPersistor = persistence.GZIPJSONSerializationPersistor
 }


### PR DESCRIPTION
Forgot to add it in earlier PRs.