### PR TITLE
Make GZIPJSONSerializationPersistor default

### DIFF
--- a/src/main/scala/org/scalameter/PerformanceTest.scala
+++ b/src/main/scala/org/scalameter/PerformanceTest.scala
@@ -91,7 +91,7 @@ object PerformanceTest {
    */
   trait HTMLReport extends PerformanceTest {
     import reporting._
-    def persistor: Persistor = new persistence.SerializationPersistor
+    def persistor: Persistor = new persistence.GZIPJSONSerializationPersistor
     def warmer: Warmer = Warmer.Default()
     def aggregator: Aggregator = Aggregator.average
     def measurer: Measurer = new Measurer.IgnoringGC with Measurer.PeriodicReinstantiation with Measurer.OutlierElimination with Measurer.RelativeNoise

--- a/src/main/scala/org/scalameter/japi/JavaPerformanceTest.scala
+++ b/src/main/scala/org/scalameter/japi/JavaPerformanceTest.scala
@@ -210,7 +210,7 @@ abstract class Microbenchmark extends JavaPerformanceTest {
 abstract class HTMLReport extends JavaPerformanceTest {
   import Executor.Measurer
   import reporting._
-  def javaPersistor: org.scalameter.japi.Persistor = new org.scalameter.japi.SerializationPersistor
+  def javaPersistor: org.scalameter.japi.Persistor = new org.scalameter.japi.GZIPJSONSerializationPersistor
   def javaWarmer = new org.scalameter.japi.Warmer {
     def get = new org.scalameter.Warmer.Default
   }


### PR DESCRIPTION
> 
The consequence of doing this is potentially breaking existing tests out there.
When we get to this point, please do this change in a separate commit - it might be necessary to introduce a new test template, or provide a migration tool from the old formats (the first is probably simpler).

So I making a new PR mainly for discussion purpose. 
Since SerialVersionUID for Parameters is changed does this mean that upgrading to future 0.7 version will need cleaning of saved regression data?