### PR TITLE
Add utility object to read all bytes from file

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/utils/IO.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/utils/IO.scala
@@ -1,0 +1,36 @@
+package org.scalameter.utils
+
+import java.io.{File, FileInputStream, ByteArrayOutputStream, InputStream}
+import scala.annotation.tailrec
+
+
+object IO {
+  /** Reads all bytes from given [[java.io.InputStream]].
+   *
+   *  Note that this method does not close supplied stream.
+   */
+  def readFromInputStream(from: InputStream, chunkSize: Int = 2048): Array[Byte] = {
+    val buffer = new Array[Byte](chunkSize)
+    val output = new ByteArrayOutputStream(chunkSize)
+
+    @tailrec
+    def _readBytes() {
+      val bytes = from.read(buffer)
+      if (bytes > -1) {
+        output.write(buffer, 0, bytes)
+        _readBytes()
+      }
+    }
+
+    _readBytes()
+    output.toByteArray
+  }
+
+  /** Reads all bytes from given [[java.io.File]]. */
+  def readFromFile(from: File, chunkSize: Int = 2048): Array[Byte] = {
+    val fis = new FileInputStream(from)
+    val bytes = readFromInputStream(fis, chunkSize)
+    fis.close()
+    bytes
+  }
+}

--- a/scalameter-core/src/test/scala/org/scalameter/utils/IOTest.scala
+++ b/scalameter-core/src/test/scala/org/scalameter/utils/IOTest.scala
@@ -1,0 +1,23 @@
+package org.scalameter.utils
+
+import java.io.{File, FileOutputStream}
+
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, FunSuite}
+
+
+class IOTest extends FunSuite with PropertyChecks with Matchers {
+  test("IO.readFromFile should slurp all bytes") {
+    forAll { o: Array[Byte] =>
+      val file = File.createTempFile("scalameter-io-readAllBytes-", ".dat")
+      file.deleteOnExit()
+
+      val fos = new FileOutputStream(file)
+      fos.write(o)
+      fos.close()
+
+      val bytes = IO.readFromFile(file, chunkSize = 8)
+      bytes should === (o)
+    }
+  }
+}

--- a/src/test/scala/org/scalameter/persistence/PersistorTest.scala
+++ b/src/test/scala/org/scalameter/persistence/PersistorTest.scala
@@ -27,7 +27,7 @@ trait PersistorTest { this: Matchers =>
   /** Checks if size of file is less than value given in kB.
    */
   def compareSpaceConsumption(location: File, maxValue: Double): Unit = {
-    val bytes = Files.readAllBytes(location.toPath)
+    val bytes = utils.IO.readFromFile(location)
     val total = bytes.length / 1024d
     total should be < maxValue
   }


### PR DESCRIPTION
Reading all bytes from file will be needed for an instrumentation.
I could use apache commons-io but since it's only one simple method I thought it's not worth adding external library.