### PR TITLE
Add descendants class matcher

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/execution/invocation/instrumentation/Instrumentation.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/execution/invocation/instrumentation/Instrumentation.scala
@@ -47,7 +47,7 @@ private[scalameter] object Instrumentation {
     } else { // if it's not directory try to read it as zip/jar file
       val zipFile = new ZipFile(in)
       zipFile.entries().asScala.collect {
-        case entry if p(entry.getName.stripSuffix(".class").replace('/', '.')) =>
+        case entry if entry.getName.endsWith(".class") && p(entry.getName.stripSuffix(".class").replace('/', '.')) =>
           entry.getName -> zipFile.getInputStream(entry)
       }
     }

--- a/scalameter-core/src/test/scala/org/scalameter/execution/invocation/InvocationCountMatcherTest.scala
+++ b/scalameter-core/src/test/scala/org/scalameter/execution/invocation/InvocationCountMatcherTest.scala
@@ -6,7 +6,7 @@ import org.scalameter.execution.invocation.InvocationCountMatcher._
 
 
 class InvocationCountMatcherTest extends FunSuite with Matchers {
-  test("StringClassMatcher should match classes") {
+  test("ClassMatcher.ClassName should match classes") {
     val matcher = ClassMatcher.ClassName(classOf[java.lang.Integer])
     matcher.matches("java.lang.Integer") should === (true)
     matcher.matches("java/lang/Integer") should === (false)
@@ -14,7 +14,7 @@ class InvocationCountMatcherTest extends FunSuite with Matchers {
     matcher.matches("java/lang/Long") should === (false)
   }
 
-  test("RegexClassMatcher should match classes") {
+  test("ClassMatcher.Regex should match classes") {
     val matcher =  ClassMatcher.Regex("(java\\.lang\\.Integer)|(java\\.lang\\.Long)".r.pattern)
     matcher.matches("java.lang.Integer") should === (true)
     matcher.matches("java.lang.Long") should === (true)
@@ -24,21 +24,47 @@ class InvocationCountMatcherTest extends FunSuite with Matchers {
     matcher.matches("java.lang.String") should === (false)
   }
 
-  test("StringMethodMatcher should match methods") {
+  test("ClassMatcher.Descendants should match classes") {
+    val matcher1 = ClassMatcher.Descendants(classOf[collection.immutable.LinearSeq[_]], direct = false, withSelf = false)
+    matcher1.matches("scala.collection.immutable.LinearSeq") should === (false)
+    matcher1.matches("scala.collection.immutable.List") should === (true)
+    matcher1.matches("scala.collection.immutable.Nil$") should === (true)
+    matcher1.matches("scala.collection.immutable.$colon$colon") should === (true)
+
+    val matcher2 = ClassMatcher.Descendants(classOf[collection.immutable.LinearSeq[_]], direct = true, withSelf = false)
+    matcher2.matches("scala.collection.immutable.LinearSeq") should === (false)
+    matcher2.matches("scala.collection.immutable.List") should === (true)
+    matcher2.matches("scala.collection.immutable.Nil$") should === (false)
+    matcher2.matches("scala.collection.immutable.$colon$colon") should === (false)
+
+    val matcher3 = ClassMatcher.Descendants(classOf[collection.immutable.LinearSeq[_]], direct = false, withSelf = true)
+    matcher3.matches("scala.collection.immutable.LinearSeq") should === (true)
+    matcher3.matches("scala.collection.immutable.List") should === (true)
+    matcher3.matches("scala.collection.immutable.Nil$") should === (true)
+    matcher3.matches("scala.collection.immutable.$colon$colon") should === (true)
+
+    val matcher4 = ClassMatcher.Descendants(classOf[collection.immutable.LinearSeq[_]], direct = true, withSelf = true)
+    matcher4.matches("scala.collection.immutable.LinearSeq") should === (true)
+    matcher4.matches("scala.collection.immutable.List") should === (true)
+    matcher4.matches("scala.collection.immutable.Nil$") should === (false)
+    matcher4.matches("scala.collection.immutable.$colon$colon") should === (false)
+  }
+
+  test("MethodMatcher.MethodName should match methods") {
     val matcher = MethodMatcher.MethodName("valueOf")
     matcher.matches("valueOf", "") should === (true)
     matcher.matches("valueOf", "") should === (true)
     matcher.matches("toString", "") should === (false)
   }
 
-  test("RegexMethodMatcher should match methods") {
+  test("MethodMatcher.Regex should match methods") {
     val matcher =  MethodMatcher.Regex("valueOf|toString".r.pattern)
     matcher.matches("valueOf", "") should === (true)
     matcher.matches("toString", "") should === (true)
     matcher.matches("", "") should === (false)
   }
 
-  test("FullMethodMatcher should match methods") {
+  test("MethodMatcher.Full should match methods") {
     val matcher =  MethodMatcher.Full(classOf[String].getMethod("valueOf", classOf[Int]))
     matcher.matches("valueOf", Type.getMethodDescriptor(classOf[String].getMethod("valueOf", classOf[Int]))) should === (true)
     matcher.matches("valueOf", Type.getMethodDescriptor(classOf[String].getMethod("valueOf", classOf[Long]))) should === (false)


### PR DESCRIPTION
I've also fixed one bug in `Instrumentation.scala` that revealed itself during testing of this matcher (rest of matchers are agnostic to non-classes)

EDIT:
Well, I've chosen bad test cases for 2.10.