### PR TITLE
Fix class instrumentation when classpath element is a non-existent file

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/execution/invocation/instrumentation/Instrumentation.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/execution/invocation/instrumentation/Instrumentation.scala
@@ -42,7 +42,8 @@ private[scalameter] object Instrumentation {
       classesFromCurrentDir ++ classessFromSubdirs
     }
 
-    if (in.isDirectory) {
+    if (!in.exists()) Iterator.empty
+    else if (in.isDirectory) {
       filterClasses(in, rootPath = "")
     } else { // if it's not directory try to read it as zip/jar file
       val zipFile = new ZipFile(in)


### PR DESCRIPTION
Fix of bug that revealed when I was writing an example for new measurers.