### PR TITLE
Add JGen.

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/picklers/package.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/picklers/package.scala
@@ -2,6 +2,11 @@ package org.scalameter
 
 
 package object picklers {
+
+}
+
+
+package picklers {
   object Implicits {
     // primitives
     implicit val unitPickler = UnitPickler

--- a/src/main/java/org/scalameter/Fun1.java
+++ b/src/main/java/org/scalameter/Fun1.java
@@ -1,0 +1,21 @@
+package org.scalameter;
+
+
+/** JGen function interface for `map` combinator.
+ *
+ *  Note that it can be used from Java code using both lambda syntax (Java 8)
+ *  and plain new instance creation (Java <= 8).
+ *
+ *  {{
+ *    JGen.range("x", 100, 1000, 100).map(x -> new int[x]) // valid for the Java 8
+ *
+ *    JGen.range("x", 100, 1000, 100).map(new Fun1<Integer, int[]>() {
+ *      public int[] apply(Integer v) {
+ *        return new int[v];
+ *      }
+ *    })
+ *  }}
+ */
+public interface Fun1<T, R> {
+  R apply(T v);
+}

--- a/src/main/java/org/scalameter/JGen.java
+++ b/src/main/java/org/scalameter/JGen.java
@@ -1,0 +1,182 @@
+package org.scalameter;
+
+import org.scalameter.picklers.*;
+import scala.Tuple2;
+import scala.Tuple3;
+import scala.Tuple4;
+import scala.collection.immutable.List;
+import scala.collection.mutable.ArrayOps;
+import scala.runtime.AbstractFunction1;
+
+
+/** Java version of the [[org.scalameter.Gen]].
+ *  After combining and changing your generators
+ *  you should finally call the `asScala()` method.
+ *
+ *  Note that it's immutable, so every method return new JGen.
+ */
+@SuppressWarnings({"unchecked"})
+public class JGen<T> {
+  private final Gen<T> gen;
+
+  public JGen(Gen<T> gen) {
+    this.gen = gen;
+  }
+
+  public Gen<T> asScala() {
+    return this.gen;
+  }
+
+  public JGen<T> cached() {
+    return new JGen<T>(gen.cached());
+  }
+
+  public <S> JGen<Tuple2<T, S>> zip(JGen<S> that) {
+    return new JGen<Tuple2<T, S>>(this.gen.zip(that.gen));
+  }
+
+  public <S> JGen<S> map(final Fun1<T, S> f) {
+    return new JGen<S>(this.gen.map(new AbstractFunction1<T, S>() {
+      public S apply(T v) {
+        return f.apply(v);
+      }
+    }));
+  }
+
+
+  /* Standard factory methods. */
+
+  public static JGen<Integer> exponential(
+      String axisName, int from, int until, int factor
+  ) {
+    return new JGen<Integer>(
+        (Gen<Integer>)(Object) Gen.exponential(axisName, from, until, factor)
+    );
+  }
+
+  public static JGen<Integer> range(
+      String axisName, int from, int upto, int hop
+  ) {
+    return new JGen<Integer>(
+        (Gen<Integer>)(Object) Gen.range(axisName, from, upto, hop)
+    );
+  }
+
+  public static JGen<Void> none(String axisName) {
+    return new JGen<Void>((Gen<Void>)(Object) Gen.unit(axisName));
+  }
+
+
+  /* Factory methods that produce cross product of multiple JGen instances. */
+
+  public static <P, Q> JGen<Tuple2<P, Q>> crossProduct(
+      JGen<P> p, JGen<Q> q
+  ) {
+    return new JGen<Tuple2<P, Q>>(
+        Gen.crossProduct(p.gen, q.gen)
+    );
+  }
+
+  public static <P, Q, R> JGen<Tuple3<P, Q, R>> crossProduct(
+      JGen<P> p, JGen<Q> q, JGen<R> r
+  ) {
+    return new JGen<Tuple3<P, Q, R>>(
+        Gen.crossProduct(p.gen, q.gen, r.gen)
+    );
+  }
+
+  public static <P, Q, R, S> JGen<Tuple4<P, Q, R, S>> crossProduct(
+      JGen<P> p, JGen<Q> q, JGen<R> r, JGen<S> s
+  ) {
+    return new JGen<Tuple4<P, Q, R, S>>(
+        Gen.crossProduct(p.gen, q.gen, r.gen, s.gen)
+    );
+  }
+
+
+  /* Factory methods that return enumerations. */
+
+  private static <T> List<T> toList(T[] array) {
+    return new ArrayOps.ofRef(array).toList();
+  }
+
+  public static JGen<Boolean> booleanValues(
+      String axisName, Boolean... values
+  ) {
+    return new JGen<Boolean>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Boolean>)(Object) Implicits.booleanPickler()
+    ));
+  }
+
+  public static JGen<Character> charValues(
+      String axisName, Character... values
+  ) {
+    return new JGen<Character>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Character>)(Object) Implicits.charPickler()
+    ));
+  }
+
+  public static JGen<Byte> byteValues(
+      String axisName, Byte... values
+  ) {
+    return new JGen<Byte>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Byte>)(Object) Implicits.bytePickler()
+    ));
+  }
+
+  public static JGen<Short> shortValues(
+      String axisName, Short... values
+  ) {
+    return new JGen<Short>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Short>)(Object) Implicits.shortPickler()
+    ));
+  }
+
+  public static JGen<Integer> intValues(
+      String axisName, Integer... values
+  ) {
+    return new JGen<Integer>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Integer>)(Object) Implicits.intPickler()
+    ));
+  }
+
+  public static JGen<Long> longValues(
+      String axisName, Long... values
+  ) {
+    return new JGen<Long>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Long>)(Object) Implicits.longPickler()
+    ));
+  }
+
+  public static JGen<Float> floatValues(
+      String axisName, Float... values
+  ) {
+    return new JGen<Float>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Float>)(Object) Implicits.floatPickler()
+    ));
+  }
+
+  public static JGen<Double> doubleValues(
+      String axisName, Double... values
+  ) {
+    return new JGen<Double>(Gen.enumeration(
+        axisName, toList(values), (Pickler<Double>)(Object) Implicits.doublePickler()
+    ));
+  }
+
+  public static <T extends Enum<T>> JGen<T> enumValues(
+      String axisName, T... values
+  ) {
+    return new JGen<T>(Gen.enumeration(
+        axisName, toList(values), (Pickler<T>) Implicits.enumPickler()
+    ));
+  }
+
+  public static <T> JGen<T> values(
+      String axisName, Pickler<T> pickler, T... values
+  ) {
+    return new JGen<T>(Gen.enumeration(
+        axisName, toList(values), pickler
+    ));
+  }
+}

--- a/src/main/scala/org/scalameter/Gen.scala
+++ b/src/main/scala/org/scalameter/Gen.scala
@@ -8,7 +8,7 @@ import org.scalameter.picklers.Implicits._
 
 
 
-trait Gen[T] extends Serializable {
+abstract class Gen[T] extends Serializable {
   self =>
 
   def map[S](f: T => S): Gen[S] = new Gen[S] {
@@ -102,14 +102,14 @@ object Gen {
 
   /* combinators */
 
-  def tupled[P, Q](p: Gen[P], q: Gen[Q]): Gen[(P, Q)] = {
+  def crossProduct[P, Q](p: Gen[P], q: Gen[Q]): Gen[(P, Q)] = {
     for {
       pv <- p
       qv <- q
     } yield (pv, qv)
   }
 
-  def tupled[P, Q, R](p: Gen[P], q: Gen[Q], r: Gen[R]): Gen[(P, Q, R)] = {
+  def crossProduct[P, Q, R](p: Gen[P], q: Gen[Q], r: Gen[R]): Gen[(P, Q, R)] = {
     for {
       pv <- p
       qv <- q
@@ -117,7 +117,7 @@ object Gen {
     } yield (pv, qv, rv)
   }
 
-  def tupled[P, Q, R, S](p: Gen[P], q: Gen[Q], r: Gen[R], s: Gen[S]): Gen[(P, Q, R, S)] = {
+  def crossProduct[P, Q, R, S](p: Gen[P], q: Gen[Q], r: Gen[R], s: Gen[S]): Gen[(P, Q, R, S)] = {
     for {
       pv <- p
       qv <- q

--- a/src/main/scala/org/scalameter/japi/GenFactory.scala
+++ b/src/main/scala/org/scalameter/japi/GenFactory.scala
@@ -79,17 +79,17 @@ class ExponentialGen(axisName: String, from: Int, until: Int, factor: Int) exten
 
 
 class TupledGen[P, Q](p: JavaGenerator[P], q: JavaGenerator[Q]) extends JavaGenerator[Tuple2[P, Q]] {
-  def get: Gen[(P, Q)] = Gen.tupled(p.get.asInstanceOf[Gen[P]], q.get.asInstanceOf[Gen[Q]])
+  def get: Gen[(P, Q)] = Gen.crossProduct(p.get.asInstanceOf[Gen[P]], q.get.asInstanceOf[Gen[Q]])
 }
 
 
 class Tupled3Gen[P, Q, R](p: JavaGenerator[P], q: JavaGenerator[Q], r: JavaGenerator[R]) extends JavaGenerator[Tuple3[P, Q, R]] {
-  def get: Gen[(P, Q, R)] = Gen.tupled(p.get.asInstanceOf[Gen[P]], q.get.asInstanceOf[Gen[Q]], r.get.asInstanceOf[Gen[R]])
+  def get: Gen[(P, Q, R)] = Gen.crossProduct(p.get.asInstanceOf[Gen[P]], q.get.asInstanceOf[Gen[Q]], r.get.asInstanceOf[Gen[R]])
 }
 
 
 class Tupled4Gen[P, Q, R, S](p: JavaGenerator[P], q: JavaGenerator[Q], r: JavaGenerator[R], s: JavaGenerator[S]) extends JavaGenerator[Tuple4[P, Q, R, S]] {
-  def get: Gen[(P, Q, R, S)] = Gen.tupled(p.get.asInstanceOf[Gen[P]], q.get.asInstanceOf[Gen[Q]], r.get.asInstanceOf[Gen[R]], s.get.asInstanceOf[Gen[S]])
+  def get: Gen[(P, Q, R, S)] = Gen.crossProduct(p.get.asInstanceOf[Gen[P]], q.get.asInstanceOf[Gen[Q]], r.get.asInstanceOf[Gen[R]], s.get.asInstanceOf[Gen[S]])
 }
 
 

--- a/src/test/scala/org/scalameter/JGenTest.scala
+++ b/src/test/scala/org/scalameter/JGenTest.scala
@@ -1,0 +1,55 @@
+package org.scalameter
+
+import org.scalameter.picklers.Implicits._
+import org.scalatest.{Matchers, FunSuite}
+
+
+class JGenTest extends FunSuite with Matchers {
+  private def validateJGen[T](jgen: JGen[T], gen:Gen[T]): Unit = {
+    jgen.asScala().dataset.toList should
+      contain theSameElementsInOrderAs gen.dataset.toList
+    jgen.asScala().dataset.zip(gen.dataset).foreach { case (j, s) =>
+      jgen.asScala().generate(j) should === (gen.generate(s))
+    }
+  }
+
+  test("JGen should correctly define simple parameters") {
+    validateJGen(
+      JGen.exponential("x", 500, 5000, 2),
+      Gen.exponential("x")(500, 5000, 2).asInstanceOf[Gen[java.lang.Integer]]
+    )
+  }
+
+  test("JGen should allow correctly define map combinator") {
+    validateJGen(
+      JGen.longValues("x", 100l, 1000l, 10000l).map(
+        new Fun1[java.lang.Long, List[Long]] {
+          def apply(v: java.lang.Long): List[Long] =
+            List.fill(100)(v)
+        }
+      ),
+      Gen.enumeration("x")(100l, 1000l, 10000l).map(List.fill(100)(_))
+    )
+  }
+
+  test("JGen should correctly produce cross product") {
+    validateJGen(
+      JGen.range("x", 100, 1000, 100).zip(JGen.booleanValues("y", true, false)),
+      Gen.range("x")(100, 1000, 100).zip(Gen.enumeration("y")(true, false))
+        .asInstanceOf[Gen[(java.lang.Integer, java.lang.Boolean)]]
+    )
+
+    validateJGen(
+      JGen.crossProduct(
+        JGen.intValues("x", 1, 2, 3),
+        JGen.booleanValues("y", true, false),
+        JGen.charValues("z", 'a', 'b', 'c', 'd', 'e')
+      ),
+      Gen.crossProduct(
+        Gen.enumeration("x")(1, 2, 3),
+        Gen.enumeration("y")(true, false),
+        Gen.enumeration("z")('a', 'b', 'c', 'd', 'e')
+      ).asInstanceOf[Gen[(java.lang.Integer, java.lang.Boolean, java.lang.Character)]]
+    )
+  }
+}

--- a/src/test/scala/org/scalameter/examples/CachedGeneratorTest.scala
+++ b/src/test/scala/org/scalameter/examples/CachedGeneratorTest.scala
@@ -14,7 +14,7 @@ class CachedGeneratorTest extends PerformanceTest.OfflineRegressionReport {
   val sizes = Gen.range("size")(100000000, 500000000, 200000000)
   val parallelismLevels = Gen.enumeration("parallelismLevel")(1, 2, 4, 8)
   val pools = (for (par <- parallelismLevels) yield new collection.parallel.ForkJoinTaskSupport(new concurrent.forkjoin.ForkJoinPool(par))).cached
-  val inputs = Gen.tupled(sizes, pools)
+  val inputs = Gen.crossProduct(sizes, pools)
 
   performance of "foreach" in {
     performance of "ParRange" in {


### PR DESCRIPTION
Good news are that users get java 8 lambda syntax support for free.. 
Lambdas are automatically converted to interfaces, [when they contain only single abstract method](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html#approach6).

Btw, I think I should be able to add next PRs tomorrow (I must write documentation for the annotations and tests for the JBench)