### PR TITLE
Rename PerformanceTest to Bench

### DIFF
--- a/src/main/scala/org/scalameter/Bench.scala
+++ b/src/main/scala/org/scalameter/Bench.scala
@@ -7,7 +7,7 @@ import org.scalameter.utils.Tree
 
 
 
-abstract class PerformanceTest extends DSL with Serializable {
+abstract class Bench extends DSL with Serializable {
 
   def main(args: Array[String]) {
     val ctx = dyn.currentContext.value ++ Main.Configuration.fromCommandLineArgs(args).context
@@ -21,12 +21,15 @@ abstract class PerformanceTest extends DSL with Serializable {
 }
 
 
-object PerformanceTest {
+object Bench {
+
+  @deprecated("Please use Bench.Quick instead", "0.7")
+  type Quickbenchmark = Quick
   
   /** Quick benchmark run in the same JVM.
    *  Reports result into the console.
    */
-  trait Quickbenchmark extends PerformanceTest {
+  trait Quick extends Bench {
     def executor: Executor = new execution.LocalExecutor(
       Warmer.Default(),
       Aggregator.min,
@@ -37,10 +40,13 @@ object PerformanceTest {
     def persistor: Persistor = Persistor.None
   }
 
+  @deprecated("Please use Bench.Micro instead", "0.7")
+  type Microbenchmark = Micro
+  
   /** A more reliable benchmark run in a separate JVM.
    *  Reports results into the console.
    */
-  trait Microbenchmark extends PerformanceTest {
+  trait Micro extends Bench {
     def warmer: Warmer = Warmer.Default()
     def aggregator: Aggregator = Aggregator.min
     def measurer: Measurer = new Measurer.IgnoringGC with Measurer.PeriodicReinstantiation {
@@ -54,7 +60,7 @@ object PerformanceTest {
 
   /** A base for benchmarks generating a more detailed (regression) report, potentially online.
    */
-  trait HTMLReport extends PerformanceTest {
+  trait HTMLReport extends Bench {
     import reporting._
     def persistor: Persistor = new persistence.GZIPJSONSerializationPersistor
     def warmer: Warmer = Warmer.Default()
@@ -100,7 +106,7 @@ object PerformanceTest {
   }
 
   @deprecated("This performance test is now deprecated, please use `OnlineRegressionReport` instead.", "0.5")
-  trait Regression extends PerformanceTest {
+  trait Regression extends Bench {
     import reporting._
     def warmer: Warmer = Warmer.Default()
     def aggregator: Aggregator = Aggregator.average

--- a/src/main/scala/org/scalameter/api.scala
+++ b/src/main/scala/org/scalameter/api.scala
@@ -27,8 +27,13 @@ object api extends Keys {
   type Context = org.scalameter.Context
   val Context = org.scalameter.Context
 
-  type PerformanceTest = org.scalameter.PerformanceTest
-  val PerformanceTest = org.scalameter.PerformanceTest
+  type Bench = org.scalameter.Bench
+  val Bench = org.scalameter.Bench
+
+  @deprecated("Please use Bench instead", "0.7")
+  type PerformanceTest = org.scalameter.Bench
+  @deprecated("Please use Bench instead", "0.7")
+  val PerformanceTest = org.scalameter.Bench
 
   type Executor = org.scalameter.Executor
   val Executor = org.scalameter.Executor

--- a/src/main/scala/org/scalameter/japi/JBench.scala
+++ b/src/main/scala/org/scalameter/japi/JBench.scala
@@ -180,7 +180,7 @@ abstract class JBench extends BasePerformanceTest with Serializable {
 }
 
 object JBench {
-  /** Annotation based equivalent of the [[org.scalameter.PerformanceTest.Quickbenchmark]] */
+  /** Annotation based equivalent of the [[org.scalameter.Bench.Quick]] */
   abstract class Quick extends JBench {
     def aggregator: Aggregator = Aggregator.min
 
@@ -199,7 +199,7 @@ object JBench {
     )
   }
 
-  /** Annotation based equivalent of the [[org.scalameter.PerformanceTest.Microbenchmark]] */
+  /** Annotation based equivalent of the [[org.scalameter.Bench.Micro]] */
   abstract class Micro extends JBench {
     def aggregator: Aggregator = Aggregator.min
 
@@ -222,7 +222,7 @@ object JBench {
     )
   }
 
-  /** Annotation base equivalent of the [[org.scalameter.PerformanceTest.HTMLReport]] */
+  /** Annotation base equivalent of the [[org.scalameter.Bench.HTMLReport]] */
   abstract class HTMLReport extends JBench {
     def aggregator: Aggregator = Aggregator.average
 
@@ -252,7 +252,7 @@ object JBench {
     def tester: RegressionReporter.Tester
   }
 
-  /** Annotation base equivalent of the [[org.scalameter.PerformanceTest.OnlineRegressionReport]] */
+  /** Annotation base equivalent of the [[org.scalameter.Bench.OnlineRegressionReport]] */
   abstract class OnlineRegressionReport extends HTMLReport {
     def historian: RegressionReporter.Historian =
       RegressionReporter.Historian.ExponentialBackoff()
@@ -263,7 +263,7 @@ object JBench {
       RegressionReporter.Tester.OverlapIntervals()
   }
 
-  /** Annotation base equivalent of the [[org.scalameter.PerformanceTest.OfflineRegressionReport]] */
+  /** Annotation base equivalent of the [[org.scalameter.Bench.OfflineRegressionReport]] */
   abstract class OfflineRegressionReport extends HTMLReport {
     def historian: RegressionReporter.Historian =
       RegressionReporter.Historian.ExponentialBackoff()
@@ -274,7 +274,7 @@ object JBench {
       RegressionReporter.Tester.OverlapIntervals()
   }
 
-  /** Annotation base equivalent of the [[org.scalameter.PerformanceTest.OfflineReport]] */
+  /** Annotation base equivalent of the [[org.scalameter.Bench.OfflineReport]] */
   abstract class OfflineReport extends HTMLReport {
     def historian: RegressionReporter.Historian =
       RegressionReporter.Historian.ExponentialBackoff()

--- a/src/main/scala/org/scalameter/utils/Reflect.scala
+++ b/src/main/scala/org/scalameter/utils/Reflect.scala
@@ -3,7 +3,7 @@ package utils
 
 object Reflect {
 
-  def singletonInstance[C](module: Class[C]) = module.getField("MODULE$").get(null).asInstanceOf[PerformanceTest]
+  def singletonInstance[C](module: Class[C]) = module.getField("MODULE$").get(null).asInstanceOf[Bench]
 
 }
 

--- a/src/test/scala/org/scalameter/InvocationCountMeasurerTest.scala
+++ b/src/test/scala/org/scalameter/InvocationCountMeasurerTest.scala
@@ -1,11 +1,11 @@
 package org.scalameter
 
-import org.scalameter.examples.InvocationCountMeasurerPerformanceTest
+import org.scalameter.examples.InvocationCountMeasurerBench
 import org.scalatest.{Matchers, FunSuite}
 
 
 abstract class InvocationCountMeasurerTest extends FunSuite with Matchers {
-  def checkInvocationCountMeasurerTest(test: InvocationCountMeasurerPerformanceTest): Any = {
+  def checkInvocationCountMeasurerTest(test: InvocationCountMeasurerBench): Any = {
     try {
       test.executeTests()
       try {

--- a/src/test/scala/org/scalameter/JSChartTest.scala
+++ b/src/test/scala/org/scalameter/JSChartTest.scala
@@ -10,7 +10,7 @@ import parallel.ParIterable
 
 
 
-class JSChartTest extends PerformanceTest.Regression with Collections {
+class JSChartTest extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/JSChartTestSimple.scala
+++ b/src/test/scala/org/scalameter/JSChartTestSimple.scala
@@ -8,7 +8,7 @@ import parallel.ParIterable
 
 
 
-class JSChartTestSimple extends PerformanceTest.Regression with Collections {
+class JSChartTestSimple extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/LoggingReporterTest.scala
+++ b/src/test/scala/org/scalameter/LoggingReporterTest.scala
@@ -2,7 +2,7 @@ package org.scalameter
 
 
 class RangeBenchmark
-extends PerformanceTest.Microbenchmark {
+extends Bench.Micro {
   val ranges = for {
     size <- Gen.range("size")(300000, 1500000, 300000)
   } yield 0 until size

--- a/src/test/scala/org/scalameter/QuickbenchmarkTest.scala
+++ b/src/test/scala/org/scalameter/QuickbenchmarkTest.scala
@@ -11,7 +11,7 @@ import org.scalameter.picklers.Implicits._
 
 class QuickbenchmarkTest extends FunSuite {
 
-  object SomeBenchmark extends PerformanceTest.Quickbenchmark {
+  object SomeBenchmark extends Bench.Quick {
     performance of "single" in {
       using(Gen.single("single")(1)) in (_ + 0)
     }

--- a/src/test/scala/org/scalameter/RangeBenchmarks.scala
+++ b/src/test/scala/org/scalameter/RangeBenchmarks.scala
@@ -38,7 +38,7 @@ extends PerformanceTest {
 
 
 object RangeBenchmark0
-extends PerformanceTest.Quickbenchmark {
+extends PerformanceTest.Quick {
 
   /* configuration */
 

--- a/src/test/scala/org/scalameter/SeqTest.scala
+++ b/src/test/scala/org/scalameter/SeqTest.scala
@@ -6,10 +6,10 @@ import collection._
 
 
 
-class RegressionSeqTest extends SeqTesting with PerformanceTest.Regression
+class RegressionSeqTest extends SeqTesting with Bench.Regression
 
 
-abstract class SeqTesting extends PerformanceTest {
+abstract class SeqTesting extends Bench {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/CollectionBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/CollectionBenchmarks.scala
@@ -6,7 +6,7 @@ package collections
 
 
 
-class CollectionBenchmarks extends PerformanceTest.Regression {
+class CollectionBenchmarks extends Bench.Regression {
 
   def persistor = new persistence.SerializationPersistor
 

--- a/src/test/scala/org/scalameter/collections/Collections.scala
+++ b/src/test/scala/org/scalameter/collections/Collections.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-trait Collections extends PerformanceTest {
+trait Collections extends Bench {
 
   /* data */
 

--- a/src/test/scala/org/scalameter/collections/MapBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/MapBenchmarks.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class MapBenchmarks extends PerformanceTest.Regression with Collections {
+class MapBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/SeqBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/SeqBenchmarks.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class SeqBenchmarks extends PerformanceTest.Regression with Collections {
+class SeqBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/SetBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/SetBenchmarks.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class SetBenchmarks extends PerformanceTest.Regression with Collections {
+class SetBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/TraversableBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/TraversableBenchmarks.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class TraversableBenchmarks extends PerformanceTest.Regression with Collections {
+class TraversableBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/fast/CollectionBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/fast/CollectionBenchmarks.scala
@@ -5,7 +5,7 @@ package collections.fast
 
 
 
-class CollectionBenchmarks extends PerformanceTest.Regression {
+class CollectionBenchmarks extends Bench.Regression {
 
   def persistor = new persistence.SerializationPersistor
 

--- a/src/test/scala/org/scalameter/collections/fast/MapBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/fast/MapBenchmarks.scala
@@ -9,7 +9,7 @@ import Key._
 
 
 
-class MapBenchmarks extends PerformanceTest.Regression with Collections {
+class MapBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/fast/SeqBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/fast/SeqBenchmarks.scala
@@ -9,7 +9,7 @@ import Key._
 
 
 
-class SeqBenchmarks extends PerformanceTest.Regression with Collections {
+class SeqBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/fast/SetBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/fast/SetBenchmarks.scala
@@ -9,7 +9,7 @@ import Key._
 
 
 
-class SetBenchmarks extends PerformanceTest.Regression with Collections {
+class SetBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/collections/fast/TraversableBenchmarks.scala
+++ b/src/test/scala/org/scalameter/collections/fast/TraversableBenchmarks.scala
@@ -9,7 +9,7 @@ import Key._
 
 
 
-class TraversableBenchmarks extends PerformanceTest.Regression with Collections {
+class TraversableBenchmarks extends Bench.Regression with Collections {
 
   def persistor = new persistence.SerializationPersistor()
 

--- a/src/test/scala/org/scalameter/examples/BeforeAfterTest.scala
+++ b/src/test/scala/org/scalameter/examples/BeforeAfterTest.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class BeforeAfterTest extends PerformanceTest.OfflineRegressionReport {
+class BeforeAfterTest extends Bench.OfflineRegressionReport {
 
   val sizes = Gen.range("size")(1000000, 5000000, 2000000)
 

--- a/src/test/scala/org/scalameter/examples/CachedGeneratorTest.scala
+++ b/src/test/scala/org/scalameter/examples/CachedGeneratorTest.scala
@@ -9,7 +9,7 @@ import org.scalameter.picklers.Implicits._
 
 
 
-class CachedGeneratorTest extends PerformanceTest.OfflineRegressionReport {
+class CachedGeneratorTest extends Bench.OfflineRegressionReport {
 
   val sizes = Gen.range("size")(100000000, 500000000, 200000000)
   val parallelismLevels = Gen.enumeration("parallelismLevel")(1, 2, 4, 8)

--- a/src/test/scala/org/scalameter/examples/MemoryTest.scala
+++ b/src/test/scala/org/scalameter/examples/MemoryTest.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class MemoryTest extends PerformanceTest.OfflineRegressionReport {
+class MemoryTest extends Bench.OfflineRegressionReport {
   override def measurer = new Measurer.MemoryFootprint
 
   val sizes = Gen.range("size")(1000000, 5000000, 2000000)

--- a/src/test/scala/org/scalameter/examples/TestSuite.scala
+++ b/src/test/scala/org/scalameter/examples/TestSuite.scala
@@ -8,7 +8,7 @@ import Key._
 
 
 
-class TestSuite extends PerformanceTest.OfflineRegressionReport {
+class TestSuite extends Bench.OfflineRegressionReport {
   include[MemoryTest]
   include[RegressionTest]
 }

--- a/src/test/scala/org/scalameter/examples/measurersRegressionTests.scala
+++ b/src/test/scala/org/scalameter/examples/measurersRegressionTests.scala
@@ -5,7 +5,7 @@ import org.scalameter.execution.invocation.InvocationCountMatcher
 import org.scalameter.persistence.InterceptingPersistor
 
 
-class InvocationCountMeasurerPerformanceTest extends PerformanceTest.OnlineRegressionReport {
+class InvocationCountMeasurerBench extends PerformanceTest.OnlineRegressionReport {
   override val persistor: InterceptingPersistor = new InterceptingPersistor(new GZIPJSONSerializationPersistor)
 
   def min: Int = 5000
@@ -19,7 +19,7 @@ class InvocationCountMeasurerPerformanceTest extends PerformanceTest.OnlineRegre
   val lists = for (sz <- sizes) yield (0 until sz).toList
 }
 
-class BoxingCountTest extends InvocationCountMeasurerPerformanceTest {
+class BoxingCountTest extends InvocationCountMeasurerBench {
   override lazy val measurer: Measurer = Measurer.BoxingCount.all()
 
   override def defaultConfig = Context(
@@ -35,7 +35,7 @@ class BoxingCountTest extends InvocationCountMeasurerPerformanceTest {
   }
 }
 
-class MethodInvocationCountTest1 extends InvocationCountMeasurerPerformanceTest {
+class MethodInvocationCountTest1 extends InvocationCountMeasurerBench {
   override lazy val measurer: Measurer = Measurer.MethodInvocationCount(
     InvocationCountMatcher.allocations(classOf[Some[_]])
   )

--- a/src/test/scala/org/scalameter/persistence/RangeBenchmark.scala
+++ b/src/test/scala/org/scalameter/persistence/RangeBenchmark.scala
@@ -4,7 +4,7 @@ import org.scalameter._
 import org.scalameter.reporting.RegressionReporter
 
 
-class RangeBenchmark(override val persistor: Persistor) extends PerformanceTest.Quickbenchmark {
+class RangeBenchmark(override val persistor: Persistor) extends Bench.Quick {
   override def reporter = new reporting.RegressionReporter(
     RegressionReporter.Tester.Accepter(),
     RegressionReporter.Historian.Complete()


### PR DESCRIPTION
As you suggested earlier in the new frontend proposal doc I've renamed also `PerformanceTest` to `Bench` and added backward-compatibility aliases.