### PR TITLE
Add additional benchmark templates

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/Aggregator.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/Aggregator.scala
@@ -2,6 +2,10 @@ package org.scalameter
 
 object Aggregator {
 
+  object Implicits {
+    implicit def mapOrdering[T]: Ordering[Map[String, T]] = Ordering.by(_.keys)
+  }
+
   def apply[T](n: String)(f: Seq[Quantity[T]] => Quantity[T]) = new Aggregator[T] {
     def name = n
 

--- a/scalameter-core/src/main/scala/org/scalameter/MeasureBuilder.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/MeasureBuilder.scala
@@ -23,7 +23,7 @@ class MeasureBuilder[T, U](
   def withMeasurer(m: Measurer[U]) =
     new MeasureBuilder(ctx, warmer, m, regen, setup, teardown, resultFunction)
 
-  def withMeasurer[V, M <: Measurer[V]](m: M, a: Seq[Quantity[V]] => Quantity[V]) =
+  def withMeasurer[V](m: Measurer[V], a: Seq[Quantity[V]] => Quantity[V]) =
     new MeasureBuilder(ctx, warmer, m, regen, setup, teardown, a)
 
   def setUp(b: T => Unit) =

--- a/src/main/scala/org/scalameter/Bench.scala
+++ b/src/main/scala/org/scalameter/Bench.scala
@@ -1,9 +1,8 @@
 package org.scalameter
 
 
-
 import org.scalameter.picklers.Implicits._
-
+import org.scalameter.picklers.Pickler
 
 
 abstract class Bench[U] extends DSL[U] with Serializable {
@@ -22,49 +21,91 @@ abstract class Bench[U] extends DSL[U] with Serializable {
 
 object Bench {
 
-  @deprecated("Please use Bench.Quick instead", "0.7")
-  type Quickbenchmark = Quick
-  
-  /** Quick benchmark run in the same JVM.
+  /** Benchmark that runs snippets in the same JVM.
    *  Reports result into the console.
    */
-  abstract class Quick extends Bench[Double] {
-    def executor: Executor[Double] = new execution.LocalExecutor(
-      Warmer.Default(),
-      Aggregator.min,
+  abstract class Local[U: Pickler] extends Bench[U] {
+    def warmer: Warmer = new Warmer.Default
+
+    def aggregator: Aggregator[U]
+
+    def executor: Executor[U] = new execution.LocalExecutor(
+      warmer,
+      aggregator,
       measurer
     )
-    def measurer: Measurer[Double] = new Measurer.Default
-    def reporter: Reporter[Double] = new reporting.LoggingReporter
+
     def persistor: Persistor = Persistor.None
+
+    def reporter: Reporter[U] = new reporting.LoggingReporter
   }
 
-  @deprecated("Please use Bench.Micro instead", "0.7")
-  type Microbenchmark = Micro
+  /** Benchmark that runs snippets in separate JVMs.
+   *  Reports result into the console.
+   */
+  abstract class Forked[U: Pickler: PrettyPrinter] extends Bench[U] {
+    def warmer: Warmer = new Warmer.Default
+
+    def aggregator: Aggregator[U]
+
+    def executor: Executor[U] = new execution.SeparateJvmsExecutor(
+      warmer,
+      aggregator,
+      measurer
+    )
+
+    def persistor: Persistor = Persistor.None
+
+    def reporter: Reporter[U] = new reporting.LoggingReporter
+  }
+
+  /** Benchmark that runs snippets in separate JVMs.
+   *  It persists results in the gzipped JSON format with appropriate reporter.
+   */
+  abstract class Persisted[U: Pickler: PrettyPrinter] extends Bench[U] {
+    def warmer: Warmer = new Warmer.Default
+
+    def aggregator: Aggregator[U]
+
+    def executor: Executor[U] = new execution.SeparateJvmsExecutor[U](
+      warmer,
+      aggregator,
+      measurer
+    )
+
+    def persistor: Persistor = new persistence.GZIPJSONSerializationPersistor
+  }
+
+  @deprecated("Please use Bench.LocalTime instead", "0.7")
+  type Quickbenchmark = LocalTime
+  
+  /** Quick benchmark runs snippets in the same JVM.
+   *  Reports execution time into the console.
+   */
+  abstract class LocalTime extends Local[Double] {
+    def measurer: Measurer[Double] = new Measurer.Default
+    def aggregator: Aggregator[Double] = Aggregator.min
+  }
+
+  @deprecated("Please use Bench.ForkedTime instead", "0.7")
+  type Microbenchmark = ForkedTime
   
   /** A more reliable benchmark run in a separate JVM.
-   *  Reports results into the console.
+   *  Reports execution time into the console.
    */
-  abstract class Micro extends Bench[Double] {
-    def warmer: Warmer = Warmer.Default()
+  abstract class ForkedTime extends Forked[Double] {
     def aggregator: Aggregator[Double] = Aggregator.min
     def measurer: Measurer[Double] = new Measurer.IgnoringGC
       with Measurer.PeriodicReinstantiation[Double] {
       override val defaultFrequency = 12
       override val defaultFullGC = true
     }
-    def executor: Executor[Double] =
-      new execution.SeparateJvmsExecutor(warmer, aggregator, measurer)
-    def reporter: Reporter[Double] = new reporting.LoggingReporter
-    def persistor: Persistor = Persistor.None
   }
 
   /** A base for benchmarks generating a more detailed (regression) report, potentially online.
    */
-  abstract class HTMLReport extends Bench[Double] {
+  abstract class HTMLReport extends Persisted[Double] {
     import reporting._
-    def persistor: Persistor = new persistence.GZIPJSONSerializationPersistor
-    def warmer: Warmer = Warmer.Default()
     def aggregator: Aggregator[Double] = Aggregator.average
     def measurer: Measurer[Double] = new Measurer.IgnoringGC
       with Measurer.PeriodicReinstantiation[Double]
@@ -72,8 +113,6 @@ object Bench {
       with Measurer.RelativeNoise {
       def numeric: Numeric[Double] = implicitly[Numeric[Double]]
     }
-    def executor: Executor[Double] =
-      new execution.SeparateJvmsExecutor(warmer, aggregator, measurer)
     def tester: RegressionReporter.Tester
     def historian: RegressionReporter.Historian
     def online: Boolean

--- a/src/main/scala/org/scalameter/PrettyPrinter.scala
+++ b/src/main/scala/org/scalameter/PrettyPrinter.scala
@@ -5,7 +5,7 @@ package org.scalameter
  *
  *  The default implementation simply calls `toString` method.
  */
-trait PrettyPrinter[T] {
+trait PrettyPrinter[T] extends Serializable {
   def prettyPrint(value: T): String
 }
 

--- a/src/main/scala/org/scalameter/api.scala
+++ b/src/main/scala/org/scalameter/api.scala
@@ -53,6 +53,7 @@ object api extends Keys {
   val Warmer = org.scalameter.Warmer
   val Measurer = org.scalameter.Measurer
 
+  type Aggregator[T] = org.scalameter.Aggregator[T]
   type Warmer = org.scalameter.Warmer
   type Measurer[T] = org.scalameter.Measurer[T]
 

--- a/src/test/java/org/scalameter/examples/JBenchExample1.java
+++ b/src/test/java/org/scalameter/examples/JBenchExample1.java
@@ -9,7 +9,7 @@ import org.scalameter.japi.annotation.*;
 @scopes({
     @scopeCtx(scope = "arrays", context = "root")
 })
-public class JBenchExample1 extends JBench.Quick {
+public class JBenchExample1 extends JBench.LocalTime {
   private Random random;
 
   public final Context root = new ContextBuilder()

--- a/src/test/scala/org/scalameter/LoggingReporterTest.scala
+++ b/src/test/scala/org/scalameter/LoggingReporterTest.scala
@@ -2,7 +2,7 @@ package org.scalameter
 
 
 class RangeBenchmark
-extends Bench.Micro {
+extends Bench.ForkedTime {
   val ranges = for {
     size <- Gen.range("size")(300000, 1500000, 300000)
   } yield 0 until size

--- a/src/test/scala/org/scalameter/QuickbenchmarkTest.scala
+++ b/src/test/scala/org/scalameter/QuickbenchmarkTest.scala
@@ -11,7 +11,7 @@ import org.scalameter.picklers.Implicits._
 
 class QuickbenchmarkTest extends FunSuite {
 
-  object SomeBenchmark extends Bench.Quick {
+  object SomeBenchmark extends Bench.LocalTime {
     performance of "single" in {
       using(Gen.single("single")(1)) in (_ + 0)
     }

--- a/src/test/scala/org/scalameter/RangeBenchmarks.scala
+++ b/src/test/scala/org/scalameter/RangeBenchmarks.scala
@@ -39,7 +39,7 @@ extends Bench[Double] {
 
 
 object RangeBenchmark0
-extends Bench.Quick {
+extends Bench.LocalTime {
 
   /* configuration */
 

--- a/src/test/scala/org/scalameter/persistence/RangeBenchmark.scala
+++ b/src/test/scala/org/scalameter/persistence/RangeBenchmark.scala
@@ -4,7 +4,7 @@ import org.scalameter._
 import org.scalameter.reporting.RegressionReporter
 
 
-class RangeBenchmark(override val persistor: Persistor) extends Bench.Quick {
+class RangeBenchmark(override val persistor: Persistor) extends Bench.LocalTime {
   override def reporter = new reporting.RegressionReporter(
     RegressionReporter.Tester.Accepter(),
     RegressionReporter.Historian.Complete()


### PR DESCRIPTION
I've added also `Ordering` for the `Map[String, T]` (needed for aggregators) and corrected `MeasureBuilder.measureWith` - additional type param was unnecessary (I was sure that I modified it accordingly in the previous PR, but well).