### PR TITLE
remove useless report impl in regression report

### DIFF
--- a/src/main/scala/org/scalameter/reporting/RegressionReporter.scala
+++ b/src/main/scala/org/scalameter/reporting/RegressionReporter.scala
@@ -26,12 +26,8 @@ case class RegressionReporter[T: Numeric](
       h
   }
 
-  def report(curvedata: CurveData[T], persistor: Persistor) {
-    val ctx = curvedata.context
-    val history = loadHistory(ctx, persistor)
-    val corresponding = if (history.curves.nonEmpty) history.curves else Seq(curvedata)
-    test(ctx, curvedata, corresponding)
-  }
+  // do nothing - data are persisted at the end
+  def report(curvedata: CurveData[T], persistor: Persistor): Unit = ()
 
   def report(results: Tree[CurveData[T]], persistor: Persistor) = {
     log("")

--- a/src/main/scala/org/scalameter/reporting/RegressionReporter.scala
+++ b/src/main/scala/org/scalameter/reporting/RegressionReporter.scala
@@ -27,7 +27,9 @@ case class RegressionReporter[T: Numeric](
   }
 
   // do nothing - data are persisted at the end
-  def report(curvedata: CurveData[T], persistor: Persistor): Unit = ()
+  def report(curvedata: CurveData[T], persistor: Persistor): Unit = {
+    log(s"Finished test set for ${curvedata.context.scope}, curve ${curvedata.context.curve}")
+  }
 
   def report(results: Tree[CurveData[T]], persistor: Persistor) = {
     log("")


### PR DESCRIPTION
The `report` method for a single test is actually doing useless computation -- result from `test` is abandoned, and recomputed in the batch `report`.