### PR TITLE
fix HTMLReporter ignores resultDir from command line

### DIFF
--- a/src/main/scala/org/scalameter/reporting/HtmlReporter.scala
+++ b/src/main/scala/org/scalameter/reporting/HtmlReporter.scala
@@ -22,7 +22,8 @@ case class HtmlReporter[T: Numeric](embedDsv: Boolean = true) extends Reporter[T
       new DsvReporter(dsvDelimiter).report(results, persistor)
     }
 
-    val resultdir = results.context(reports.resultDir)
+    // resultDir is global setting
+    val resultdir = currentContext(reports.resultDir)
     val root = new File(resultdir, "report")
     root.mkdirs()
 

--- a/src/test/scala/org/scalameter/ResultDirTest.scala
+++ b/src/test/scala/org/scalameter/ResultDirTest.scala
@@ -1,0 +1,37 @@
+package org.scalameter
+
+import org.scalameter.examples._
+import org.scalatest.FunSuite
+import java.io._
+
+
+class ResultDirTest extends FunSuite {
+  // java.io.File doesn't support recursive delete
+  def removeAll(path: String) = {
+    def getRecursively(f: File): Seq[File] =
+      f.listFiles.filter(_.isDirectory).flatMap(getRecursively) ++ f.listFiles
+
+    getRecursively(new File(path)).foreach { f => f.delete() }
+
+    new File(path).delete
+  }
+
+  test("test setting result directory from command line") {
+    try {
+      val dir = "_testReport"
+      val file = new File(dir)
+      if (file.exists) removeAll(file.getPath)
+
+      new RegressionTest main(Array(s"-CresultDir $dir"))
+
+      val report = new File(dir, "report")
+      assert(report.exists)
+
+      removeAll(file.getPath)
+    } catch { case t: Throwable =>
+      t.printStackTrace()
+      throw t
+    }
+  }
+}
+


### PR DESCRIPTION
Currently `resultDir` is ignored by the HTMLReporter if it's passed from command line.

This commit fixes the bug. The same problem exists for `v0.6`, but I'm not sure if it's worth to back port to `v0.6`.

More trickily, if user defines `persistor` and `reporter` via `val` instead of `def`, `resultDir` would be ignored as well. This is because the instances are created using the default context before the command line option is parsed by `Bench.main` and update `dyn.currentContext`.