### PR TITLE
Use original dataset keys in cached generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp*
 .gitattributes
 
 .metadata/
+.idea/

--- a/src/main/scala/org/scalameter/Gen.scala
+++ b/src/main/scala/org/scalameter/Gen.scala
@@ -68,7 +68,7 @@ abstract class Gen[T] extends Serializable {
 
     def axes = cachedDataset.head._1.axisData.keys.toSet
     def warmupset = cachedWarmupset.iterator
-    def dataset = cachedDataset.keys.iterator
+    def dataset = self.dataset
     def generate(params: Parameters) = {
       val desiredParams = Parameters(params.axisData.filterKeys(k => axes.contains(k)).toSeq: _*)
       cachedDataset(desiredParams)

--- a/src/main/scala/org/scalameter/reporting/LoggingReporter.scala
+++ b/src/main/scala/org/scalameter/reporting/LoggingReporter.scala
@@ -22,7 +22,7 @@ case class LoggingReporter[T]() extends Reporter[T] {
 
     // output measurements
     for (measurement <- result.measurements) {
-      log(s"${measurement.params}: ${measurement.value}")
+      log(s"${measurement.params}: ${measurement.value} ${measurement.units}")
     }
 
     // add a new line


### PR DESCRIPTION
In case of cached generators, it uses `cachedDataset.keys.iterator` which is not sorted now (as `cachedDataset` is a Map).

The result might look like this:

```
[info] Parameters(count -> 14000): 7.809987 ms
[info] Parameters(count -> 18000): 9.897271 ms
[info] Parameters(count -> 6000): 4.036777 ms
[info] Parameters(count -> 2000): 1.17128 ms
[info] Parameters(count -> 10000): 6.067992 ms
[info] Parameters(count -> 22000): 12.183311 ms
```

It's a minor fix that change it to `self.dataset` since it's the original sorted parameters. Then, the result will preserve the original sorted parameter order.

```
[info] Parameters(count -> 2000): 1.088965 ms
[info] Parameters(count -> 6000): 3.399998 ms
[info] Parameters(count -> 10000): 5.604467 ms
[info] Parameters(count -> 14000): 7.908225 ms
[info] Parameters(count -> 18000): 10.218699 ms
[info] Parameters(count -> 22000): 12.391421 ms
```

Also, I added time unit to `LoggingReporter`. I think it's more explicit, especially, when share the benchmark result to someone else.