### PR TITLE
HtmlReporter now loads the correct static files

### DIFF
--- a/src/main/scala/org/scalameter/reporting/HtmlReporter.scala
+++ b/src/main/scala/org/scalameter/reporting/HtmlReporter.scala
@@ -1,12 +1,11 @@
 package org.scalameter
 package reporting
 
-
-
 import java.io._
 import org.scalameter.Key._
 import org.scalameter.utils.Tree
 import scala.collection._
+import scala.collection.JavaConverters._
 import scala.util.parsing.json.{JSONObject, JSONArray}
 
 
@@ -148,7 +147,15 @@ object HtmlReporter {
   val dsvDelimiter = '\t'
 
   def copyResource(from: String, to: File) {
-    val res = getClass.getClassLoader.getResourceAsStream(from)
+    val resources = getClass.getClassLoader.getResources(from).asScala
+    val resource = resources.find { url =>
+      url.getPath.contains("scalameter")
+    }
+
+    val res = resource match {
+      case Some(url) => url.openStream()
+      case None => throw new IllegalStateException(s"Could not find any resource with name $from.")
+    }
     try {
       val buffer = new Array[Byte](1024)
       val fos = new FileOutputStream(to)


### PR DESCRIPTION
Fixes #182.
Updated `HtmlReporter` to load the correct static files in case there are name clashes. For example, if there are multiple `index.html` files on the classpath, the ScalaMeter `index.html` file will now correctly be loaded.

I updated the code I listed in #182 to be a bit nicer. Also, I committed directly to `master`. If this is a problem please let me know.