### PR TITLE
Fallback to loopback address if DNS lookup to get hostname fails

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/Context.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/Context.scala
@@ -68,15 +68,27 @@ object Context {
     verbose -> false
   )
 
-  def machine = Context(
-    Key.machine.jvm.version -> sys.props("java.vm.version"),
-    Key.machine.jvm.vendor -> sys.props("java.vm.vendor"),
-    Key.machine.jvm.name -> sys.props("java.vm.name"),
-    Key.machine.osName -> sys.props("os.name"),
-    Key.machine.osArch -> sys.props("os.arch"),
-    Key.machine.cores -> Runtime.getRuntime.availableProcessors,
-    Key.machine.hostname -> java.net.InetAddress.getLocalHost.getHostName
-  )
+  def machine = {
+    def hostname = {
+      val localAddress = try {
+        java.net.InetAddress.getLocalHost
+      } catch {
+        case _: java.net.UnknownHostException => // DNS lookup failure
+          java.net.InetAddress.getLoopbackAddress
+      }
+      localAddress.getHostName
+    }
+
+    Context(
+      Key.machine.jvm.version -> sys.props("java.vm.version"),
+      Key.machine.jvm.vendor -> sys.props("java.vm.vendor"),
+      Key.machine.jvm.name -> sys.props("java.vm.name"),
+      Key.machine.osName -> sys.props("os.name"),
+      Key.machine.osArch -> sys.props("os.arch"),
+      Key.machine.cores -> Runtime.getRuntime.availableProcessors,
+      Key.machine.hostname -> hostname
+    )
+  }
 
   @deprecated(
     "This implicit will be removed in 0.6. Replace config(opts: _*) with config(opts).",


### PR DESCRIPTION
This is a fix for #158. 

The cause for the `java.net.UnknownHostException` thrown while `org.scalameter.Context` is being initialized is that `java.net.InetAddress.getLocalHost()` attempts to connect to DNS to get a real hostname and IP address (such as "my.laptop.corp.com" and "192.1.254.68"). In some cases when `getLocalHost()` fails (e.g. `java.lang.SecurityException`), it returns the loopback address instead (hostname = "localhost"; address = "127.0.0.1").

The solution implemented in this PR is basically the same: if the DNS lookup fails scalameter fallbacks to the loopback address. In that case `org.scalameter.Context.hostname` is set to `localhost`