### PR TITLE
Inline mode not very useful with application code due to lack of return value

### DIFF
--- a/src/test/scala/org/scalameter/inlinebenches/InlineBenchmarkTest.scala
+++ b/src/test/scala/org/scalameter/inlinebenches/InlineBenchmarkTest.scala
@@ -16,6 +16,14 @@ class InlineBenchmarkTest extends FunSuite {
     println(s"Total time: $time")
   }
 
+  test("Should return result of measured function") {
+    val (result, time) = measured {
+      for (i <- 0 until 100000) yield i
+    }
+    println(s"Total time: $time")
+    assert(result.length == 100000)
+  }
+
   test("Should correctly execute an inline benchmark with warming") {
     val time = config(
       Key.exec.benchRuns -> 20,


### PR DESCRIPTION
So inline benchmark is supposed to be helpful in benchmarking parts of application but the `measure` and `measureWith` methods do not return the value of the function being benchmarked.
Since scala code is usually functional this makes inline benchmark quite useless in most cases without extra wrapper.

Can you change/add methods to return tuple of `(S, Quantity[U])` instead? 