### PR TITLE
ContextBuilderTest: fix intermittent test failure

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/src/test/scala/org/scalameter/japi/ContextBuilderTest.scala
+++ b/src/test/scala/org/scalameter/japi/ContextBuilderTest.scala
@@ -7,15 +7,16 @@ import org.scalatest.{FunSuite, Matchers}
 
 class ContextBuilderTest extends FunSuite with Matchers {
   test("ContextBuilder should create the same context as direct context creation") {
+    val default = ClassPath.default
     val expected = Context(
       exec.benchRuns -> 30,
       verbose -> false,
-      classpath -> ClassPath.default
+      classpath -> default
     )
     val actual = new ContextBuilder()
       .put("exec.benchRuns", 30)
       .put("verbose", false)
-      .put("classpath", ClassPath.default)
+      .put("classpath", default)
       .build()
 
     actual should === (expected)


### PR DESCRIPTION
this came up in the Scala 2.13 community build at e.g.:
https://scala-ci.typesafe.com/job/scala-2.13.x-integrate-community-build/3543/artifact/logs/scalameter-build.log
I was also able to reproduce the failure on 2.13.2 and outside of dbuild

`ClassPath.default` doesn't always come back in the same order (?!), hence the occasional failures

I also threw in an sbt version bump, to align with what the community build uses, to reduce the number of possible causes needing investigation when something fails