### PR TITLE
Encode existential type in KeyValue in Scala 3 compatible way

### DIFF
--- a/scalameter-core/src/main/scala/org/scalameter/Context.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/Context.scala
@@ -12,7 +12,7 @@ case class Context(properties: immutable.Map[Key[_], Any]) {
   def -[T](t: Key[T]) = Context(properties - t)
   def +[T](t: (Key[T], T)) = Context(properties + t)
   def ++(that: Context) = Context(this.properties ++ that.properties)
-  def ++(that: Seq[KeyValue]) = Context(this.properties ++ that)
+  def ++(that: Seq[KeyValue]) = Context(this.properties ++ that.map(_.get))
   def get[T](key: Key[T]): Option[T] =
     properties.get(key).asInstanceOf[Option[T]].orElse {
       key match {
@@ -44,28 +44,28 @@ case class Context(properties: immutable.Map[Key[_], Any]) {
 
 
 object Context {
-  def apply(xs: KeyValue*) = new Context(xs.asInstanceOf[Seq[(Key[_], Any)]].toMap)
+  def apply(xs: KeyValue*) = new Context(xs.map(_.get).asInstanceOf[Seq[(Key[_], Any)]].toMap)
 
   val empty = new Context(immutable.Map.empty)
 
   val topLevel = machine ++ Context(
-    preJDK7 -> false,
-    dsl.scope -> Nil,
-    exec.benchRuns -> 36,
-    exec.minWarmupRuns -> 10,
-    exec.maxWarmupRuns -> 50,
-    exec.jvmflags -> List("-Xmx2048m", "-Xms2048m"),
-    classpath -> utils.ClassPath.default,
-    reports.regression.significance -> 1e-10,
-    verbose -> false
+    preJDK7 := false,
+    dsl.scope := Nil,
+    exec.benchRuns := 36,
+    exec.minWarmupRuns := 10,
+    exec.maxWarmupRuns := 50,
+    exec.jvmflags := List("-Xmx2048m", "-Xms2048m"),
+    classpath := utils.ClassPath.default,
+    reports.regression.significance := 1e-10,
+    verbose := false
   )
 
   val inlineBenchmarking = machine ++ Context(
-    exec.benchRuns -> 1,
-    exec.minWarmupRuns -> 10,
-    exec.maxWarmupRuns -> 50,
-    exec.requireGC -> false,
-    verbose -> false
+    exec.benchRuns := 1,
+    exec.minWarmupRuns := 10,
+    exec.maxWarmupRuns := 50,
+    exec.requireGC := false,
+    verbose := false
   )
 
   def machine = {
@@ -80,13 +80,13 @@ object Context {
     }
 
     Context(
-      Key.machine.jvm.version -> sys.props("java.vm.version"),
-      Key.machine.jvm.vendor -> sys.props("java.vm.vendor"),
-      Key.machine.jvm.name -> sys.props("java.vm.name"),
-      Key.machine.osName -> sys.props("os.name"),
-      Key.machine.osArch -> sys.props("os.arch"),
-      Key.machine.cores -> Runtime.getRuntime.availableProcessors,
-      Key.machine.hostname -> hostname
+      Key.machine.jvm.version := sys.props("java.vm.version"),
+      Key.machine.jvm.vendor := sys.props("java.vm.vendor"),
+      Key.machine.jvm.name := sys.props("java.vm.name"),
+      Key.machine.osName := sys.props("os.name"),
+      Key.machine.osArch := sys.props("os.arch"),
+      Key.machine.cores := Runtime.getRuntime.availableProcessors,
+      Key.machine.hostname := hostname
     )
   }
 

--- a/scalameter-core/src/main/scala/org/scalameter/InvocationCount.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/InvocationCount.scala
@@ -78,10 +78,10 @@ trait InvocationCount extends Measurer[Map[String, Long]] {
     jar.deleteOnExit()
 
     context ++ Context(
-      exec.measurers.methodInvocationLookupTable ->
+      exec.measurers.methodInvocationLookupTable :=
         mutable.ArrayBuffer.empty[MethodSignature],
-      exec.measurers.instrumentedJarPath -> jar,
-      finalClasspath -> (jar +: cl)
+      exec.measurers.instrumentedJarPath := jar,
+      finalClasspath := (jar +: cl)
     )
   }
 

--- a/scalameter-core/src/main/scala/org/scalameter/keys.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/keys.scala
@@ -37,8 +37,27 @@ extends PicklerBasedKey[T] {
   }
 
   val pickler: Pickler[T] = implicitly[Pickler[T]]
+
+  def := (value: T): KeyValue.OfType[T] =
+    KeyValue(this -> value)
+
 }
 
+trait KeyValue {
+  type T
+  def get: (Key[T], T)
+}
+
+object KeyValue {
+
+  type OfType[T0] = KeyValue { type T = T0 }
+
+  def apply[T0](pair: (Key[T0], T0)): KeyValue.OfType[T0] =
+    new KeyValue {
+      type T = T0
+      def get = pair
+    }
+}
 
 /** Base for keys that have some kind of default value. */
 class KeyWithDefault[T: Pickler](name: String)(implicit container: KeyContainer)

--- a/scalameter-core/src/main/scala/org/scalameter/package.scala
+++ b/scalameter-core/src/main/scala/org/scalameter/package.scala
@@ -5,7 +5,6 @@ package org
 import scala.collection._
 import scala.language.implicitConversions
 import scala.language.postfixOps
-import scala.language.existentials
 
 
 
@@ -18,8 +17,6 @@ package object scalameter extends MeasureBuilder[Unit, Double](
   MeasureBuilder.doNothing,
   MeasureBuilder.average
 ) {
-
-  type KeyValue = (Key[T], T) forSome { type T }
 
   private[scalameter] object dyn {
     val currentContext = new MonadicDynVar(Context.topLevel)

--- a/src/main/scala/org/scalameter/Executor.scala
+++ b/src/main/scala/org/scalameter/Executor.scala
@@ -27,7 +27,7 @@ trait Executor[V] {
     val time = System.currentTimeMillis()
     var result: Tree[CurveData[V]] = null
     val runContext = currentContext ++ Seq(
-      Key.exec.overallBegin -> time
+      Key.exec.overallBegin := time
     )
     for (_ <- dyn.currentContext.using(runContext)) {
       result = for (setup <- setuptree) yield {

--- a/src/main/scala/org/scalameter/Main.scala
+++ b/src/main/scala/org/scalameter/Main.scala
@@ -52,30 +52,30 @@ object Main {
         case names => Configuration(names, Context.empty)
       }
       def intsetting: Parser[Configuration] = "-" ~ ident ~ (decimalNumber | "true" | "false") ^^ {
-        case _ ~ "Cminwarmups" ~ num => Configuration(Nil, Context(exec.minWarmupRuns -> num.toInt))
-        case _ ~ "Cmaxwarmups" ~ num => Configuration(Nil, Context(exec.maxWarmupRuns -> num.toInt))
-        case _ ~ "Cruns" ~ num => Configuration(Nil, Context(exec.benchRuns -> num.toInt))
-        case _ ~ "Ccolors" ~ flag => Configuration(Nil, Context(reports.colors -> flag.toBoolean))
+        case _ ~ "Cminwarmups" ~ num => Configuration(Nil, Context(exec.minWarmupRuns := num.toInt))
+        case _ ~ "Cmaxwarmups" ~ num => Configuration(Nil, Context(exec.maxWarmupRuns := num.toInt))
+        case _ ~ "Cruns" ~ num => Configuration(Nil, Context(exec.benchRuns := num.toInt))
+        case _ ~ "Ccolors" ~ flag => Configuration(Nil, Context(reports.colors := flag.toBoolean))
       }
       def path: Parser[String] = opt("/") ~ repsep("""[\w\d-\.]+""".r, "/") ~ opt("/") ^^ {
         case lead ~ ps ~ trail => lead.getOrElse("") + ps.mkString("/") + trail.getOrElse("")
       }
       def resdir: Parser[Configuration] = "-" ~ "CresultDir" ~ path ^^ {
-        case _ ~ _ ~ s => Configuration(Nil, Context(reports.resultDir -> s))
+        case _ ~ _ ~ s => Configuration(Nil, Context(reports.resultDir := s))
       }
       def stringLit = "['\"]".r ~ rep("[^'']".r) ~ "['\"]".r ^^ {
         case _ ~ cs ~ _ => cs.mkString
       }
       def scopefilter: Parser[Configuration] = "-" ~ "CscopeFilter" ~ (stringLit | failure("scopeFilter must be followed by a single or double quoted string.")) ^^ {
-        case _ ~ _ ~ s => Configuration(Nil, Context(scopeFilter -> s))
+        case _ ~ _ ~ s => Configuration(Nil, Context(scopeFilter := s))
       }
       def shortscopefilter: Parser[Configuration] = "-z" ~ ("""[a-zA-Z\.]+""".r) ^^ {
-        case _ ~ s => Configuration(Nil, Context(scopeFilter -> s))
+        case _ ~ s => Configuration(Nil, Context(scopeFilter := s))
       }
       def flag: Parser[Configuration] = "-" ~ ("silent" | "verbose" | "preJDK7") ^^ {
-        case _ ~ "verbose" => Configuration(Nil, Context(Key.verbose -> true))
-        case _ ~ "silent" => Configuration(Nil, Context(Key.verbose -> false))
-        case _ ~ "preJDK7" => Configuration(Nil, Context(Key.preJDK7 -> true))
+        case _ ~ "verbose" => Configuration(Nil, Context(Key.verbose := true))
+        case _ ~ "silent" => Configuration(Nil, Context(Key.verbose := false))
+        case _ ~ "preJDK7" => Configuration(Nil, Context(Key.preJDK7 := true))
       }
 
       parseAll(arguments, args.mkString(" ")) match {

--- a/src/main/scala/org/scalameter/execution/SeparateJvmsExecutor.scala
+++ b/src/main/scala/org/scalameter/execution/SeparateJvmsExecutor.scala
@@ -27,7 +27,7 @@ class SeparateJvmsExecutor[V: Pickler : PrettyPrinter](
 
   def createJvmContext(ctx: Context) = {
     ctx ++ Seq(
-      exec.overallBegin -> currentContext(exec.overallBegin)
+      exec.overallBegin := currentContext(exec.overallBegin)
     )
   }
 
@@ -42,8 +42,8 @@ class SeparateJvmsExecutor[V: Pickler : PrettyPrinter](
     }
     var result: Tree[CurveData[V]] = null
     val newContext = currentContext ++ Seq(
-      exec.setupCount -> count,
-      exec.setupIndex -> 0
+      exec.setupCount := count,
+      exec.setupIndex := 0
     )
     for (_ <- dyn.currentContext.using(newContext)) {
       result = super.run(setuptree, reporter, persistor)
@@ -190,7 +190,7 @@ class SeparateJvmsExecutor[V: Pickler : PrettyPrinter](
     }
 
     dyn.currentContext.value = currentContext ++ Seq(
-      exec.setupIndex -> (currentContext(exec.setupIndex) + 1)
+      exec.setupIndex := (currentContext(exec.setupIndex) + 1)
     )
 
     CurveData(measurements.toSeq, Map.empty, context)

--- a/src/test/scala/org/scalameter/JUnitOnlineRegressionReportTest.scala
+++ b/src/test/scala/org/scalameter/JUnitOnlineRegressionReportTest.scala
@@ -14,8 +14,8 @@ class JUnitOnlineRegressionReportTest
 extends OnlineRegressionReport  {
 
   override def defaultConfig = super.defaultConfig ++ Context(
-    reports.resultDir -> dir.getAbsolutePath,
-    reports.regression.noiseMagnitude -> 0.1
+    reports.resultDir := dir.getAbsolutePath,
+    reports.regression.noiseMagnitude := 0.1
   )
 
   @Test
@@ -34,8 +34,8 @@ extends OnlineRegressionReport  {
     performance of "Array" in {
       measure method "foreach" in {
         using(arrays) config (
-          exec.independentSamples -> 1
-          ) in { xs =>
+          exec.independentSamples := 1
+        ) in { xs =>
           var sum = 0
           xs.foreach(x => sum += x)
         }

--- a/src/test/scala/org/scalameter/examples/BeforeAfterTest.scala
+++ b/src/test/scala/org/scalameter/examples/BeforeAfterTest.scala
@@ -16,8 +16,8 @@ class BeforeAfterTest extends Bench.OfflineReport {
     measure method "toArray" in {
 
       using(sizes) config (
-        exec.benchRuns -> 10,
-        exec.independentSamples -> 1
+        exec.benchRuns := 10,
+        exec.independentSamples := 1
       ) beforeTests {
         println("ABOUT TO START RANGE TESTS!")
       } afterTests {

--- a/src/test/scala/org/scalameter/examples/grouped-tests.scala
+++ b/src/test/scala/org/scalameter/examples/grouped-tests.scala
@@ -3,13 +3,13 @@ package examples
 
 class TestSuite extends Bench.Group {
   performance of "memory" config(
-    Key.reports.resultDir -> "target/benchmarks/memory"
+    Key.reports.resultDir := "target/benchmarks/memory"
   ) in {
     include(new MemoryTest2 {})
   }
 
   performance of "running time" config(
-    Key.reports.resultDir -> "target/benchmarks/time"
+    Key.reports.resultDir := "target/benchmarks/time"
   ) in {
     include(new RegressionTest3 {})
   }

--- a/src/test/scala/org/scalameter/examples/measurers-tests.scala
+++ b/src/test/scala/org/scalameter/examples/measurers-tests.scala
@@ -13,7 +13,7 @@ trait Snippet[U] extends Bench[U] {
   val sizes = Gen.single("size")(300000)
 
   override def defaultConfig = Context(
-    verbose -> false
+    verbose := false
   )
 
   val ranges = for {
@@ -21,9 +21,9 @@ trait Snippet[U] extends Bench[U] {
   } yield 0 until size
   
   performance of "Range" config(
-    exec.benchRuns -> 10,
-    exec.independentSamples -> 2,
-    verbose -> false
+    exec.benchRuns := 10,
+    exec.independentSamples := 2,
+    verbose := false
   ) in {
     measure method "map" in {
       using(ranges) in {
@@ -96,7 +96,7 @@ class BoxingCountBench extends InvocationCountMeasurerBench {
   )
 
   override def defaultConfig = Context(
-    exec.independentSamples -> 1
+    exec.independentSamples := 1
   )
 
   performance of "List" in {
@@ -115,8 +115,8 @@ class MethodInvocationCountBench extends InvocationCountMeasurerBench {
   ).map(v => v.copy(value = v.value.valuesIterator.sum.toDouble))
 
   override def defaultConfig = Context(
-    exec.independentSamples -> 1,
-    verbose -> false
+    exec.independentSamples := 1,
+    verbose := false
   )
 
   performance of "List" in {

--- a/src/test/scala/org/scalameter/examples/memory-tests.scala
+++ b/src/test/scala/org/scalameter/examples/memory-tests.scala
@@ -11,10 +11,10 @@ class MemoryTest extends Bench.OfflineReport {
   performance of "MemoryFootprint" in {
     performance of "Array" in {
       using(sizes) config (
-        exec.minWarmupRuns -> 2,
-        exec.maxWarmupRuns -> 5,
-        exec.benchRuns -> 5,
-        exec.independentSamples -> 1
+        exec.minWarmupRuns := 2,
+        exec.maxWarmupRuns := 5,
+        exec.benchRuns := 5,
+        exec.independentSamples := 1
       ) in { sz =>
         (0 until sz).toArray
       }
@@ -32,10 +32,10 @@ trait MemoryTest2 extends Bench.OfflineReport {
   performance of "MemoryFootprint" in {
     performance of "Array" in {
       using(sizes) config (
-        exec.minWarmupRuns -> 2,
-        exec.maxWarmupRuns -> 5,
-        exec.benchRuns -> 30,
-        exec.independentSamples -> 1
+        exec.minWarmupRuns := 2,
+        exec.maxWarmupRuns := 5,
+        exec.benchRuns := 30,
+        exec.independentSamples := 1
       ) in { sz =>
         (0 until sz).toArray
       }

--- a/src/test/scala/org/scalameter/examples/regression-tests.scala
+++ b/src/test/scala/org/scalameter/examples/regression-tests.scala
@@ -2,6 +2,7 @@ package org.scalameter.examples
 
 
 
+import org.scalameter.KeyValue
 import org.scalameter.api._
 import org.scalameter.picklers.Implicits._
 
@@ -16,7 +17,7 @@ class RegressionTest extends Bench.OfflineReport {
   performance of "Array" in {
     measure method "foreach" in {
       using(arrays) config (
-        exec.independentSamples -> 1
+        exec.independentSamples := 1
       ) in { xs =>
         var sum = 0
         xs.foreach(x => sum += x)
@@ -36,9 +37,9 @@ class RegressionTest2 extends Bench.OfflineReport {
   performance of "List" in {
     measure method "map" in {
       using(lists) config (
-        exec.benchRuns -> 20,
-        exec.independentSamples -> 1,
-        exec.reinstantiation.frequency -> 2
+        exec.benchRuns := 20,
+        exec.independentSamples := 1,
+        exec.reinstantiation.frequency := 2
       ) in { xs =>
         xs.map(_ + 1)
       }
@@ -57,10 +58,10 @@ trait RegressionTest3 extends Bench.OfflineReport {
   performance of "List" in {
     measure method "groupBy" in {
       using(lists) config (
-        exec.benchRuns -> 20,
-        exec.independentSamples -> 1,
-        exec.outliers.covMultiplier -> 1.5,
-        exec.outliers.suspectPercent -> 40
+        exec.benchRuns := 20,
+        exec.independentSamples := 1,
+        exec.outliers.covMultiplier := 1.5,
+        exec.outliers.suspectPercent := 40
       ) in { xs =>
         xs.groupBy(_ % 10)
       }

--- a/src/test/scala/org/scalameter/inlinebenches/InlineBenchmarkTest.scala
+++ b/src/test/scala/org/scalameter/inlinebenches/InlineBenchmarkTest.scala
@@ -26,8 +26,8 @@ class InlineBenchmarkTest extends FunSuite {
 
   test("Should correctly execute an inline benchmark with warming") {
     val time = config(
-      Key.exec.benchRuns -> 20,
-      Key.verbose -> true
+      Key.exec.benchRuns := 20,
+      Key.verbose := true
     ) withWarmer {
       new Warmer.Default
     } withMeasurer {
@@ -40,7 +40,7 @@ class InlineBenchmarkTest extends FunSuite {
 
   test("Should correctly measure memory footprint") {
     val mem = config(
-      Key.exec.benchRuns -> 20
+      Key.exec.benchRuns := 20
     ) withMeasurer(new Measurer.MemoryFootprint) measure {
       for (i <- 0 until 100000) yield i
     }
@@ -49,7 +49,7 @@ class InlineBenchmarkTest extends FunSuite {
 
   test("Should correctly measure gc cycles") {
     val gc = config(
-      Key.exec.benchRuns -> 30
+      Key.exec.benchRuns := 30
     ) withMeasurer(new Measurer.GarbageCollectionCycles, Aggregator.median[Int]) measure {
       for (i <- 0 until 15000000) yield i
     }

--- a/src/test/scala/org/scalameter/japi/ContextBuilderTest.scala
+++ b/src/test/scala/org/scalameter/japi/ContextBuilderTest.scala
@@ -9,9 +9,9 @@ class ContextBuilderTest extends FunSuite with Matchers {
   test("ContextBuilder should create the same context as direct context creation") {
     val default = ClassPath.default
     val expected = Context(
-      exec.benchRuns -> 30,
-      verbose -> false,
-      classpath -> default
+      exec.benchRuns := 30,
+      verbose := false,
+      classpath := default
     )
     val actual = new ContextBuilder()
       .put("exec.benchRuns", 30)

--- a/src/test/scala/org/scalameter/japi/JBenchExample1Test.scala
+++ b/src/test/scala/org/scalameter/japi/JBenchExample1Test.scala
@@ -21,10 +21,10 @@ class JBenchExample1Test extends FunSuite with Matchers {
     setupTree.context should === (Context.topLevel + (verbose -> false))
     setupTree.foreach { setup =>
       (setup.context - dsl.curve) should === (Context.topLevel ++ Context(
-        verbose -> false,
-        exec.benchRuns -> benchs,
-        exec.maxWarmupRuns -> warmups,
-        dsl.scope -> List("forloops", "arrays")
+        verbose := false,
+        exec.benchRuns := benchs,
+        exec.maxWarmupRuns := warmups,
+        dsl.scope := List("forloops", "arrays")
       ))
       expectedCurves.contains(setup.context(dsl.curve)) should === (true)
       expectedCurves -= setup.context(dsl.curve)


### PR DESCRIPTION
This commit essentially applies the recipe given in the migration guide:
https://scalacenter.github.io/scala-3-migration-guide/docs/incompatibilities/dropped-features.html#existential-type